### PR TITLE
More policy tests

### DIFF
--- a/.github/workflows/pull-request-extra-test.yml
+++ b/.github/workflows/pull-request-extra-test.yml
@@ -16,28 +16,46 @@ on:
       types: [opened, synchronize, reopened]
 
 jobs:
-  run_extra_tests:
+  # tests that we are not debugging at the moment,
+  # tests that can run in parallel with pytest-xdist
+  # it's ok to run only on br-ne1
+  extra_tests_dist:
     strategy:
       fail-fast: false
       matrix:
         category:
           - policy
           - acl
+        config:
+          - "../params/br-ne1.yaml"
+    uses: ./.github/workflows/run-tests.yml
+    with:
+      config: "${{ matrix.config }}"
+      flags: "-v -n auto --color yes -m '${{ matrix.category }}'"
+      # runner: "self-hosted"
+    secrets:
+      PROFILES: ${{ secrets.PROFILES }}
+
+  # tests that we want to see all logging messages
+  # tests that we want to test on both regions
+  extra_tests_debug:
+    strategy:
+      fail-fast: false
+      matrix:
+        category:
           - bucket_versioning
         config:
           - "../params/br-ne1.yaml"
           - "../params/br-se1.yaml"
     uses: ./.github/workflows/run-tests.yml
     with:
-      tests: "*_test.py"
       config: "${{ matrix.config }}"
-      # no multiple workers here just to make it easier to audit the logs (more verbosity with INFO level)
       flags: "-v --log-cli-level INFO --color yes -m '${{ matrix.category }}'"
     secrets:
       PROFILES: ${{ secrets.PROFILES }}
 
   cleanup_tests:
-    needs: [run_extra_tests]
+    needs: [extra_tests_debug, extra_tests_dist]
     if: always()
     uses: ./.github/workflows/cleanup-tests.yml
     secrets:

--- a/.github/workflows/pull-request-extra-test.yml
+++ b/.github/workflows/pull-request-extra-test.yml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         category:
+          - policy
           - acl
           - bucket_versioning
         config:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,7 +3,7 @@ name: Run Tests
 on:
     workflow_call:
       inputs:
-        tests: { required: false, type: string }
+        tests: { required: false, type: string, default: "*_test.py"}
         config: { required: true, type: string }
         flags: { required: true, type: string }
         runner: { required: false, type: string, default: "ubuntu-24.04" }
@@ -53,4 +53,5 @@ jobs:
             - name: Run tests ${{ inputs.tests }}
               run: |
                 cd docs
+                sha256sum $(which mgc rclone aws)
                 uv run pytest --config ${{ inputs.config }} ${{ inputs.tests }} ${{ inputs.flags }}

--- a/docs/policies_test.py
+++ b/docs/policies_test.py
@@ -125,10 +125,11 @@ def test_denied_policy_operations_by_owner(s3_client, bucket_with_one_object_pol
     #retrieve the method passed as argument
     method = getattr(s3_client, boto3_action)
     try:
-        method(**kwargs)
-        logging.info(method)
+        response = method(**kwargs)
+        logging.info(f"Method response:{response}")
         pytest.fail("Expected exception not raised")
     except ClientError as e:
+        logging.info(f"Method error response:{e.response}")
         assert e.response['Error']['Code'] == 'AccessDeniedByBucketPolicy'
 
 

--- a/docs/policies_test.py
+++ b/docs/policies_test.py
@@ -6,6 +6,17 @@
 #   language_info:
 #     name: python
 # ---
+
+# # Bucket Policy (política de bucket)
+# 
+# Buckets de armazenamento por padrão são acessíveis apenas pela dona da conta que criou este 
+# recurso. Também por padrão, esta dona possui a permissão de executar **qualquer** operação
+# neste bucket e nos seus objetos. Configurar uma política de bucket é uma maneira de
+# modificar estas permissões padrões, seja para **restringir** de forma granular o número de operações
+# que podem ser executadas em um bucket ou objeto, e por quais contas ("Principals"), seja para
+# **conceder** mais acessos a determinados recursos, e para quais contas.
+
+# + {"jupyter": {"source_hidden": true}}
 import pytest
 import logging
 from botocore.exceptions import ClientError
@@ -13,10 +24,31 @@ from s3_helpers import(
     change_policies_json,
 )
 
-# # Policy Tests
 pytestmark = pytest.mark.policy
+# -
 
-# ### Test Variables
+# Políticas de bucket são descritas por meio de arquivos no formato JSON, que seguem uma gramática
+# específica, devem conter uma lista de regras _Statement_ onde cada ítem desta lista descreve um
+# `Effect` (`Allow` ou `Deny`), um campo `Principal` para descrever a(s) beneficiária(s) da regra
+# um campo `Action` com as operações que esta regra permite ou nega e um campo `Resource`, que
+# define a qual recurso esta regra se aplicará. As regras desta sintaxe pode ser consultada no
+# documento [Estrutura de uma Bucket Policy](https://docs.magalu.cloud/docs/storage/object-storage/access-control/bucket_policy_overview#estrutura-de-uma-bucket-policy)
+# Abaixo um modelo de documento de política sem os campos preenchidos:
+
+policy_dict_template = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "",
+            "Principal": "",
+            "Action": "",
+            "Resource": ""
+        }
+    ]
+}
+
+# + {"jupyter": {"source_hidden": true}}
+# Exemplos de documentos inválidos:
 malformed_policy_json ='''{
     "Version": "2012-10-18",
     "Statement": [
@@ -42,7 +74,6 @@ misspeled_policy = """{
     ]
 }
 """
-
 wrong_version_policy = """{
     "Version": "2012-10-18",
     "Statement": 
@@ -56,27 +87,19 @@ wrong_version_policy = """{
 }
 """
 
-policy_dict_template = {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "",
-            "Principal": "",
-            "Action": "",
-            "Resource": ""
-        }
-    ]
-}
-
-
 cases = [
     *[(case, "MalformedJSON") for case in ['', 'jason',"''", misspeled_policy, wrong_version_policy]],
     *[(case, "MalformedPolicy") for case in ['{}','""', malformed_policy_json]],
  ]   
+# -
+
+# ## Atribuindo uma política a um bucket usando Python
+#
+# O método para atribuir uma bucket policy na biblioteca boto3 é o [put_bucket_policy](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/put_bucket_policy.html), se o documento de política for válido o retorno trará um HTTPStatusCode `204` enquanto
+# se o documento for inválido por algum motivo uma _exception_ do tipo `ClientError` será levantada,
+# como mostram os testes abaixo:
 
 @pytest.mark.parametrize('input, expected_error', cases)
-
-# ## Asserting the possible combinations that raise errors on put_bucket_policy
 def test_put_invalid_bucket_policy(s3_client, existing_bucket_name, input, expected_error):
     try:
         s3_client.put_bucket_policy(Bucket=existing_bucket_name, Policy=input)
@@ -91,7 +114,6 @@ def test_put_invalid_bucket_policy(s3_client, existing_bucket_name, input, expec
     {"policy_dict": policy_dict_template, "actions": "s3:GetObject", "effect": "Deny"},
     {"policy_dict": policy_dict_template, "actions": "s3:DeleteObject", "effect": "Deny"}
 ])
-# ## Base case of putting a policy into a bcuket
 def test_setup_policies(s3_client, existing_bucket_name, policies_args):
     bucket_name = existing_bucket_name
 
@@ -99,18 +121,20 @@ def test_setup_policies(s3_client, existing_bucket_name, policies_args):
     policies = change_policies_json(existing_bucket_name, policies_args, "*")
     response = s3_client.put_bucket_policy(Bucket=bucket_name, Policy=policies) 
     assert response['ResponseMetadata']['HTTPStatusCode'] == 204
-    
-# # Tests related to actions on the bucket
+
+# ## Negar operações específicas em objetos
+#
+# Regras com o `Effect` `Deny` impedem que determinadas operações sejam executadas, uma conta
+# que sem a política poderia realizar estas operações (exemplos: put_object, delete_object,
+# get_object), quando executadas num objeto que é alvo de uma política contendo o `Effect` `Deny`,
+# falham com o erro `AccessDeniedByPolicy`, como demonstra o teste a seguir:
 
 number_clients = 2
-
 @pytest.mark.parametrize('multiple_s3_clients, bucket_with_one_object_policy, boto3_action', [
     ({"number_clients": number_clients}, {"policy_dict": policy_dict_template, "actions": "s3:PutObject", "effect": "Deny"}, 'put_object'),
     ({"number_clients": number_clients}, {"policy_dict": policy_dict_template, "actions": "s3:GetObject", "effect": "Deny"}, 'get_object'),
     ({"number_clients": number_clients}, {"policy_dict": policy_dict_template, "actions": "s3:DeleteObject", "effect": "Deny"}, 'delete_object')
 ], indirect = ['multiple_s3_clients', 'bucket_with_one_object_policy'])
-
-# ## Asserting if the owner has permissions blocked from own bucket
 def test_denied_policy_operations_by_owner(s3_client, bucket_with_one_object_policy, boto3_action):
     bucket_name, object_key = bucket_with_one_object_policy
     kwargs = {
@@ -120,7 +144,7 @@ def test_denied_policy_operations_by_owner(s3_client, bucket_with_one_object_pol
 
     #PutObject needs another variable
     if boto3_action == 'put_object' :
-        kwargs['Body'] = 'The answer for everthong is 42'
+        kwargs['Body'] = 'The answer for everthing is 42'
         
     #retrieve the method passed as argument
     method = getattr(s3_client, boto3_action)
@@ -132,14 +156,18 @@ def test_denied_policy_operations_by_owner(s3_client, bucket_with_one_object_pol
         logging.info(f"Method error response:{e.response}")
         assert e.response['Error']['Code'] == 'AccessDeniedByBucketPolicy'
 
+# ## Permitir operações específicas em objetos
+#
+# Da mesma forma, uma política pode dar um acesso a uma conta para determinadas operações. Uma
+# conta que sem política normalmente seria barrada com um erro `403` para operações como put_object,
+# get_object, delete_object, etc, por meio de uma política com `Effect` `Allow` conseguem obter
+# sucesso (status `200`, `204` e similares) como demostra o teste abaixo:
 
 @pytest.mark.parametrize('multiple_s3_clients, bucket_with_one_object_policy, boto3_action, expected', [
     ({"number_clients": number_clients}, {"policy_dict": policy_dict_template, "actions": "s3:PutObject", "effect": "Allow", "Principal": "*"}, 'put_object', 200),
     ({"number_clients": number_clients}, {"policy_dict": policy_dict_template, "actions": "s3:GetObject", "effect": "Allow", "Principal": "*"}, 'get_object', 200),
     ({"number_clients": number_clients}, {"policy_dict": policy_dict_template, "actions": "s3:DeleteObject", "effect": "Allow", "Principal": "*"}, 'delete_object', 204)
 ], indirect = ['multiple_s3_clients', 'bucket_with_one_object_policy'])
-
-# ## Asserting if the owner has permissions allowed from own bucket
 def test_allow_policy_operations_by_owner(multiple_s3_clients, bucket_with_one_object_policy, boto3_action,expected):
     bucket_name, object_key = bucket_with_one_object_policy
 
@@ -150,7 +178,7 @@ def test_allow_policy_operations_by_owner(multiple_s3_clients, bucket_with_one_o
 
     #PutObject needs another variable
     if boto3_action == 'put_object' :
-        kwargs['Body'] = 'The answer for everthong is 42'
+        kwargs['Body'] = 'The answer for everthing is 42'
         
     #retrieve the method passed as argument
     method = getattr(multiple_s3_clients[0], boto3_action)

--- a/docs/policies_test.py
+++ b/docs/policies_test.py
@@ -156,8 +156,6 @@ test_cases_actions_and_methods = [
     {"action": "s3:PutObject", "boto3_action": "put_object"},
     {"action": "s3:GetObject", "boto3_action": "get_object"},
     {"action": "s3:DeleteObject", "boto3_action": "delete_object"},
-    {"action": "s3:PutBucketObjectLockConfiguration", "boto3_action": "put_object_lock_configuration"},
-    {"action": "s3:GetBucketObjectLockConfiguration", "boto3_action": "get_object_lock_configuration"},
 ]
 test_cases = [
     ({"number_clients": number_clients}, {"policy_dict": policy_dict_template, "actions": item["action"], "effect": "Deny"}, item["boto3_action"])
@@ -180,10 +178,6 @@ def test_denied_policy_operations_by_owner(s3_client, bucket_with_one_object_pol
     if boto3_action == 'put_object' :
         kwargs['Body'] = 'The answer for everthing is 42'
 
-    # put_object_lock_configuration expects a ObjectLockConfiguration argument
-    if boto3_action == 'put_object_lock_configuration' :
-        kwargs['ObjectLockConfiguration'] = policy_dict_template
-
     # put_object_retention expects a Retention argument
     if boto3_action == 'put_object_retention' :
         kwargs['Retention'] = {
@@ -192,6 +186,7 @@ def test_denied_policy_operations_by_owner(s3_client, bucket_with_one_object_pol
         }
 
     #retrieve the method passed as argument
+    logging.info(f"call boto3_action:{boto3_action}, with args:{kwargs}")
     method = getattr(s3_client, boto3_action)
     try:
         response = method(**kwargs)

--- a/docs/policies_test.py
+++ b/docs/policies_test.py
@@ -16,14 +16,20 @@
 # que podem ser executadas em um bucket ou objeto, e por quais contas ("Principals"), seja para
 # **conceder** mais acessos a determinados recursos, e para quais contas.
 
+# + tags=["parameters"]
+config = "../params/br-ne1.yaml"
+# -
+
 # + {"jupyter": {"source_hidden": true}}
+import os
 import pytest
 import logging
 from botocore.exceptions import ClientError
 from s3_helpers import(
+    run_example,
     change_policies_json,
 )
-
+config = os.getenv("CONFIG", config)
 pytestmark = pytest.mark.policy
 # -
 
@@ -107,6 +113,7 @@ def test_put_invalid_bucket_policy(s3_client, existing_bucket_name, input, expec
     except ClientError as e:
         # Assert the error code matches the expected one 
         assert e.response['Error']['Code'] == expected_error
+run_example(__name__, "test_put_invalid_bucket_policy", config=config)
 
 
 @pytest.mark.parametrize('policies_args', [
@@ -121,6 +128,7 @@ def test_setup_policies(s3_client, existing_bucket_name, policies_args):
     policies = change_policies_json(existing_bucket_name, policies_args, "*")
     response = s3_client.put_bucket_policy(Bucket=bucket_name, Policy=policies) 
     assert response['ResponseMetadata']['HTTPStatusCode'] == 204
+run_example(__name__, "test_setup_policies", config=config)
 
 # ## Negar operações específicas em objetos
 #
@@ -155,6 +163,7 @@ def test_denied_policy_operations_by_owner(s3_client, bucket_with_one_object_pol
     except ClientError as e:
         logging.info(f"Method error response:{e.response}")
         assert e.response['Error']['Code'] == 'AccessDeniedByBucketPolicy'
+run_example(__name__, "test_denied_policy_operations_by_owner", config=config)
 
 # ## Permitir operações específicas em objetos
 #
@@ -184,3 +193,4 @@ def test_allow_policy_operations_by_owner(multiple_s3_clients, bucket_with_one_o
     method = getattr(multiple_s3_clients[0], boto3_action)
     response = method(**kwargs)
     assert response['ResponseMetadata']['HTTPStatusCode'] == expected
+run_example(__name__, "test_allow_policy_operations_by_owner", config=config)

--- a/docs/s3_helpers.py
+++ b/docs/s3_helpers.py
@@ -1,4 +1,5 @@
 import os
+
 import boto3
 from botocore.exceptions import ClientError
 from datetime import datetime, timedelta
@@ -263,8 +264,9 @@ def change_policies_json(bucket, policy_args: dict, tenants: list) -> json:
     policy["Statement"][0]["Effect"] = effect
     policy["Statement"][0]["Principal"] = tenants
     policy["Statement"][0]["Action"] = actions
-    policy["Statement"][0]["Resource"] = bucket + "/*"
+    policy["Statement"][0]["Resource"] = [bucket + "/*", bucket]
         
+    logging.info(f"POLICY: {json.dumps(policy)}")
     return json.dumps(policy)
 
 

--- a/params.example.yaml
+++ b/params.example.yaml
@@ -3,8 +3,10 @@ default_profile_index: 0
 profiles:
   -
     profile_name: "br-se1"
+    policy_wait_time: 120
   -
     profile_name: "br-se1-second"
+    policy_wait_time: 120
   -
     profile_name: "br-ne1"
   -

--- a/params/br-ne1.yaml
+++ b/params/br-ne1.yaml
@@ -5,7 +5,9 @@ profiles:
     profile_name: "br-ne1"
     lock_mode: "COMPLIANCE"
     # mgc_path: "../magalu/mgc/cli/mgc"
+    policy_wait_time: 0
   -
     profile_name: "br-ne1-second"
     lock_mode: "COMPLIANCE"
     # mgc_path: "../magalu/mgc/cli/mgc"
+    policy_wait_time: 0

--- a/params/br-se1.yaml
+++ b/params/br-se1.yaml
@@ -4,6 +4,8 @@ profiles:
   -
     profile_name: "br-se1"
     lock_mode: "COMPLIANCE"
+    policy_wait_time: 120
   -
     profile_name: "br-se1-second"
     lock_mode: "COMPLIANCE"
+    policy_wait_time: 120


### PR DESCRIPTION
Em preparação para as novas actions, relativas a BucketLocking que poderão ser utilizadas em policies. Ajustes nos testes existentes foram necessários.

Aproveitei também para aproximar os testes de policy, que anteriormente não funcionavam como documentação executável (nao continha paragrafos em Markdown) para, na medida do possível serem notebooks minimamente coerentes, então este patch contém alguns refactors além do suporte a actions de locking nas policies.