### PR TITLE
Turn mgc cli version into a variable/input of the run tests workflow

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -18,6 +18,10 @@ on:
           description: 'Machine to run the tests'
           default: 'ubuntu-24.04'
           required: false
+        mgc_version:
+          description: 'Version of the MGC CLI'
+          default: '0.34.0'
+          required: false
 
 jobs:
   run-tests:
@@ -27,5 +31,6 @@ jobs:
       config: ${{ inputs.config }}
       flags: ${{ inputs.flags }}
       runner: ${{ inputs.runner }}
+      mgc_version: ${{ inputs.mgc_version }}
     secrets:
       PROFILES: ${{ secrets.PROFILES }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,7 @@ on:
         config: { required: true, type: string }
         flags: { required: true, type: string }
         runner: { required: false, type: string }
+        mgc_version: { required: false, type: string, default: "0.34.0" }
       secrets:
         PROFILES: { required: true }
 jobs:
@@ -35,7 +36,8 @@ jobs:
               run: uv sync --no-dev
             - name: Install MGC
               run: |
-                curl -Lo mgc.tar.gz "https://github.com/MagaluCloud/mgccli/releases/download/v0.31.0/mgccli_0.31.0_linux_amd64.tar.gz"
+                MGC_VERSION="${{ inputs.mgc_version }}"
+                curl -Lo mgc.tar.gz "https://github.com/MagaluCloud/mgccli/releases/download/v${MGC_VERSION}/mgccli_${MGC_VERSION}_linux_amd64.tar.gz"
                 tar xzvf mgc.tar.gz 
                 rm mgc.tar.gz
                 cp "./mgc" /usr/local/bin/mgc


### PR DESCRIPTION
Updating the mgc version today requires changes in two places of a hardcoded string. And we dont have a way to use the manually triggered tests with different versions of the mgc.

This patch turns the version into a variable that can be passed as an argument to the workflow, what can make it easier to write test matrices including different versions of the cli in the future, and make it simple to change the default version to be used when new releases comes.