### PR TITLE
remove head_object from retention tests

### DIFF
--- a/params/br-ne1.yaml
+++ b/params/br-ne1.yaml
@@ -4,4 +4,4 @@ profiles:
   -
     profile_name: "br-ne1"
     lock_mode: "COMPLIANCE"
-    mgc_path: "../magalu/mgc/cli/mgc"
+    # mgc_path: "../magalu/mgc/cli/mgc"


### PR DESCRIPTION
On Amazon it is possible to check the retention details of an object using a head_object call. On Magalu Cloud this information is not returned.

This patch replaces head_object with get_object_retention calls on the locking and locking_cli tests.