### PR TITLE
Split PR CI in two (one essential/fast and one optional/slow/verbose)

### DIFF
--- a/.github/workflows/pull-request-extra-test.yml
+++ b/.github/workflows/pull-request-extra-test.yml
@@ -1,0 +1,45 @@
+# Tests that for one reason or another we dont want to make it a blocker for PRs
+# it may be because they are slow, or because tey include features still in 
+# preview/not fully launched.
+#
+# It's ok for the output to be verbose as they might be here to help in the debugging
+# of some behavior/flakiness.
+#
+# It's ok for tests here to fail or to be slow. They should not block any CI pipelines.
+#
+# Here we also run the tests on both regions.
+
+name: Pull Request Extra Tests
+
+on:
+    pull_request:
+      types: [opened, synchronize, reopened]
+
+jobs:
+  run_extra_tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        category:
+          - acl
+          - bucket_versioning
+        config:
+          - "../params/br-ne1.yaml"
+          - "../params/br-se1.yaml"
+    uses: ./.github/workflows/run-tests.yml
+    with:
+      tests: "*_test.py"
+      config: "${{ matrix.config }}"
+      # no multiple workers here just to make it easier to audit the logs (more verbosity with INFO level)
+      flags: "-v --log-cli-level INFO --color yes -m '${{ matrix.category }}'"
+    secrets:
+      PROFILES: ${{ secrets.PROFILES }}
+
+  cleanup_tests:
+    needs: [run_extra_tests]
+    if: always()
+    uses: ./.github/workflows/cleanup-tests.yml
+    secrets:
+      PROFILES: ${{ secrets.PROFILES }}
+
+

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -1,60 +1,45 @@
-name: Run Test - Pull Request
+# Tests that must pass in order for a PR to be allowed on the main branch
+# it is expected that they finish fast, thal ALL tests pass
+# and no verbose logging / debugging is enabled.
+#
+# They should run as much as possible in parallel.
+
+name: Pull Request Essential Tests
 
 on:
     pull_request:
       types: [opened, synchronize, reopened]
 
 jobs:
-  run-tests:
+  run_tests:
     strategy:
       fail-fast: true
       matrix:
         category:
-          #- acl
           - cold_storage
           - basic
           - presign
-          - bucket_versioning
-          # - policy
+        config:
+          - "../params.example.yaml"
     uses: ./.github/workflows/run-tests.yml
     with:
       tests: "*_test.py"
-      config: "../params.example.yaml"
+      config: "${{ matrix.config }}"
       flags: "-v -n auto --color yes -m '${{ matrix.category }}' --tb=line"
     secrets:
       PROFILES: ${{ secrets.PROFILES }}
+
   tests-success:
     runs-on: ubuntu-24.04
-    needs: [run-tests]
+    needs: [run_tests]
     steps:
       - name: ok
         run:
           exit 0
 
-  # since locking is a feature currently under preview, we run it separatedely
-  # and dont block merges if they fail
-  run-locking-tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        category:
-          - not cli and locking
-        config:
-          - "../params/br-ne1.yaml"
-          - "../params/br-se1.yaml"
-    uses: ./.github/workflows/run-tests.yml
-    with:
-      tests: "*_test.py"
-      config: "${{ matrix.config }}"
-      # no multiple workers here just to make it easier to audit the logs (more verbosity with INFO level)
-      flags: "-v --log-cli-level INFO --color yes -m '${{ matrix.category }}'"
-    secrets:
-      PROFILES: ${{ secrets.PROFILES }}
-
-  cleanup-tests:
-    needs: [tests-success, run-locking-tests]
+  cleanup_tests:
+    needs: [run_tests]
     if: always()
     uses: ./.github/workflows/cleanup-tests.yml
     secrets:
       PROFILES: ${{ secrets.PROFILES }}
-

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,7 +6,7 @@ on:
         tests: { required: false, type: string }
         config: { required: true, type: string }
         flags: { required: true, type: string }
-        runner: { required: false, type: string }
+        runner: { required: false, type: string, default: "ubuntu-24.04" }
         mgc_version: { required: false, type: string, default: "0.34.0" }
       secrets:
         PROFILES: { required: true }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ across Object Storage providers.
 ### Browse Documentation Online
 
 Navigate the latest documentation generated from executed specs at:  
-https://marmotitude.github.io/s3-specs/
+https://magalucloud.github.io/s3-specs/
 
 ### Run and Browse Locally
 
@@ -50,7 +50,7 @@ This is an open project, and we welcome contributions in the form of new or impr
 
 ### Suggesting Specifications
 
-Open an issue on the [issues page](https://github.com/marmotitude/s3-specs/issues), explaining the
+Open an issue on the [issues page](https://github.com/magalucloud/s3-specs/issues), explaining the
 feature, scenarios, and steps you'd like to see described as an executable specification.
 
 ### Writing Specifications

--- a/params/br-ne1.yaml
+++ b/params/br-ne1.yaml
@@ -5,3 +5,7 @@ profiles:
     profile_name: "br-ne1"
     lock_mode: "COMPLIANCE"
     # mgc_path: "../magalu/mgc/cli/mgc"
+  -
+    profile_name: "br-ne1-second"
+    lock_mode: "COMPLIANCE"
+    # mgc_path: "../magalu/mgc/cli/mgc"

--- a/params/br-se1.yaml
+++ b/params/br-se1.yaml
@@ -4,3 +4,6 @@ profiles:
   -
     profile_name: "br-se1"
     lock_mode: "COMPLIANCE"
+  -
+    profile_name: "br-se1-second"
+    lock_mode: "COMPLIANCE"


### PR DESCRIPTION
 This will allow us to accept PRs in the main branch faster, while still having a lot of test runs in the queue to check and debug new stuff.