### PR TITLE
More locking tests

### DIFF
--- a/.github/workflows/pull-request-extra-test.yml
+++ b/.github/workflows/pull-request-extra-test.yml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         category:
+          - bucket_versioning
           - policy
           - acl
         config:
@@ -43,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         category:
-          - bucket_versioning
+          - locking
         config:
           - "../params/br-ne1.yaml"
           - "../params/br-se1.yaml"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+custom-mgc/*
+
 params.yaml
 
 # Ignore all .ipynb_checkpoints folders anywhere in the project

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -331,7 +331,7 @@ def lockeable_bucket_name(s3_client, lock_mode):
         logging.error(f"Cleanup error for bucket '{bucket_name}': {e}")
 
 @pytest.fixture
-def bucket_with_lock(lockeable_bucket_name, s3_client, lock_mode):
+def bucket_with_lock(lockeable_bucket_name, s3_client, lock_mode, lock_wait_time):
     """
     Fixture to create a bucket with Object Lock and a default retention configuration.
 
@@ -354,6 +354,11 @@ def bucket_with_lock(lockeable_bucket_name, s3_client, lock_mode):
         }
     }
     put_object_lock_configuration_with_determination(s3_client, bucket_name, configuration)
+
+    # wait for the bucket lock change to be effective
+    wait_time = lock_wait_time
+    logging.info(f"Put bucket lock config might take time to propagate. Wait more {wait_time} seconds")
+    time.sleep(wait_time)
 
     logging.info(f"Bucket '{bucket_name}' configured with Object Lock and default retention.")
 

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -56,6 +56,10 @@ def policy_wait_time(default_profile):
     return default_profile.get("policy_wait_time", 0)
 
 @pytest.fixture
+def lock_wait_time(default_profile):
+    return default_profile.get("lock_wait_time", 0)
+
+@pytest.fixture
 def profile_name(default_profile):
     return (
         default_profile.get("profile_name")

--- a/docs/utils/locking.py
+++ b/docs/utils/locking.py
@@ -1,0 +1,17 @@
+import pytest
+import logging
+from utils.utils import generate_valid_bucket_name
+from s3_helpers import cleanup_old_buckets
+
+@pytest.fixture
+def bucket_with_lock_enabled(s3_client, request):
+    # use test name as base name for the bucket
+    bucket_name = generate_valid_bucket_name(request.node.name)
+    response = s3_client.create_bucket(Bucket=bucket_name, ObjectLockEnabledForBucket=True)
+
+    yield bucket_name
+
+    try:
+        cleanup_old_buckets(s3_client, base_name, lock_mode)
+    except Exception as e:
+        print(f"Cleanup error {e}")

--- a/docs/utils/utils.py
+++ b/docs/utils/utils.py
@@ -14,7 +14,7 @@ def generate_valid_bucket_name(base_name="my-unique-bucket"):
 
     # assuring base name is a string
     try:
-        base_name = ("test-" + str(base_name) + unique_id).lower()
+        base_name = ("test-" + str(base_name.replace("_", "-")) + unique_id).lower()
     except Exception as e:
         raise Exception(f"Error converting base_name to string: {e}")
 

--- a/params/br-ne1.yaml
+++ b/params/br-ne1.yaml
@@ -6,8 +6,12 @@ profiles:
     lock_mode: "COMPLIANCE"
     # mgc_path: "../magalu/mgc/cli/mgc"
     policy_wait_time: 0
+    lock_wait_time: 0
+    # mgc_path: ../custom-mgc/mgc
   -
     profile_name: "br-ne1-second"
     lock_mode: "COMPLIANCE"
     # mgc_path: "../magalu/mgc/cli/mgc"
     policy_wait_time: 0
+    lock_wait_time: 0
+    # mgc_path: ../custom-mgc/mgc

--- a/params/br-se1.yaml
+++ b/params/br-se1.yaml
@@ -5,7 +5,10 @@ profiles:
     profile_name: "br-se1"
     lock_mode: "COMPLIANCE"
     policy_wait_time: 120
+    lock_wait_time: 120
+    # mgc_path: ../custom-mgc/mgc
   -
     profile_name: "br-se1-second"
     lock_mode: "COMPLIANCE"
     policy_wait_time: 120
+    # mgc_path: ../custom-mgc/mgc


### PR DESCRIPTION
Três casos de locking, antes não cobertos por testes, com este patch passam a ser: 

- na CLI, unset de default lock config para buckets
- no boto, criação de bucket ja com locking e criação de object já com retention
- allow/deny de actions de locking via bucket policy

Adicionalmente, a introdução de mais waiters e configs de tempos de waiters para que os testes em SE1 principalmente fiquem mais tolerantes (e demorem mais) `a triste realidade da demora no atingimento de consistência eventual.