### PR TITLE
feat: add testcases to prosigned url tests

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -205,14 +205,18 @@ def bucket_with_one_object_and_cold_storage_class(s3_client):
     # Teardown: Delete the object and bucket after the test
     delete_object_and_wait(s3_client, bucket_name, object_key)
     delete_bucket_and_wait(s3_client, bucket_name)
-@pytest.fixture
-def bucket_with_one_object(s3_client):
+
+@pytest.fixture(params=[{'object_key': 'test-object.txt'}])
+def bucket_with_one_object(request, s3_client):
+    # this fixture accepts an optional request.param['object_key'] if you
+    # need a custom specific key name for your test
+    object_key = request.param['object_key']
+
     # Generate a unique bucket name and ensure it exists
     bucket_name = generate_unique_bucket_name(base_name="fixture-bucket")
     create_bucket_and_wait(s3_client, bucket_name)
 
-    # Define the object key and content, then upload the object
-    object_key = "test-object.txt"
+    # Define the object content, then upload the object
     content = b"Sample content for testing presigned URLs."
     put_object_and_wait(s3_client, bucket_name, object_key, content)
 

--- a/docs/presigned-urls_test.py
+++ b/docs/presigned-urls_test.py
@@ -41,6 +41,16 @@ config = os.getenv("CONFIG", config)
 # Posteriormente faz o download deste objeto através da URL temporária gerada.
 
 # +
+@pytest.mark.parametrize(
+    "bucket_with_one_object", 
+    [
+        { "object_key": "object-key.txt"}, 
+        { "object_key": "another/object-key"}, 
+        { "object_key": "an/object/key/with/many/slashes.txt"}, 
+        { "object_key": "an/object/key/with/many/slashes/Nome de Arquivo grandão e com acentuação 🎉 🥳 😘.txt"}, 
+    ],
+    indirect = True,
+)
 def test_presigned_get_url(s3_client, bucket_with_one_object):
     bucket_name, object_key, content = bucket_with_one_object
 
@@ -72,11 +82,19 @@ run_example(__name__, "test_presigned_get_url", config=config)
 # Gera uma URL para upload (PUT) de um objeto e utiliza essa URL para enviar dados ao bucket S3.
 
 # +
-def test_presigned_put_url(s3_client, existing_bucket_name):
+@pytest.mark.parametrize(
+    "object_key", 
+    [
+        "object-key.txt", 
+        "another/object-key", 
+        "an/object/key/with/many/slashes.txt"
+        "an/object/key/with/many/slashes/Nome de Arquivo grandão e com acentuação 🎉 🥳 😘.txt",
+    ]
+)
+def test_presigned_put_url(s3_client, existing_bucket_name, object_key):
     bucket_name = existing_bucket_name
 
-    # Define the object key and content
-    object_key = "test-upload-object.txt"
+    # Define the object content
     content = b"Sample content for presigned PUT test."
 
     # Generate a presigned PUT URL
@@ -170,7 +188,6 @@ def test_presigned_put_url_with_acl(s3_client, existing_bucket_name):
 
 run_example(__name__, "test_presigned_put_url", config=config)
 # -
-
 
 # ## Referências:
 # - [Boto3 Documentation: Presigned URLs](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-presigned-urls.html)


### PR DESCRIPTION
## Objetivo do PR
Este PR adiciona casos de teste com "subfolders" nos testes de URL pré-assinada

## Motivo do PR
Durante minhas férias um ticket de cliente apontou para um bug com paths contendo subpaths onde a presigned url não estava funcionando.

## Expectativa do PR
Espera-se que o caso antes não coberto de presigned urls para objetos cuja object key contenha o caractere barra agora esteja coberto, e por consequência uma regressão deste bug, caso volte, seja detectada.

## Link do Card no Kanban
[STK E610](https://kanban-force.web.app/boards/63d991aaf03baf6cfdc0f999?cardId=67bf26047fd136d6f729e610)

> This patch includes testcases of object keys containing slashes like if the file were in a subfolder path. There was a know issue > related with slashes in the presigned urls that is already fixed so this test is here to prevent any regression.
> 
> This patch modifies an existing "bucket_with_one_object" fixture to accept an optional indirect parameter to set the object name. This fixture change should be backwards compatible.
