### PR TITLE
feat: new test, download object using mgc cli

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -206,7 +206,9 @@ def bucket_with_one_object_and_cold_storage_class(s3_client):
     delete_object_and_wait(s3_client, bucket_name, object_key)
     delete_bucket_and_wait(s3_client, bucket_name)
 
-@pytest.fixture(params=[{'object_key': 'test-object.txt'}])
+@pytest.fixture(params=[{
+'object_key': 'test-object.txt'
+}])
 def bucket_with_one_object(request, s3_client):
     # this fixture accepts an optional request.param['object_key'] if you
     # need a custom specific key name for your test
@@ -226,6 +228,33 @@ def bucket_with_one_object(request, s3_client):
     # Teardown: Delete the object and bucket after the test
     delete_object_and_wait(s3_client, bucket_name, object_key)
     delete_bucket_and_wait(s3_client, bucket_name)
+
+@pytest.fixture(params=[{
+    'object_prefix': "",
+    'object_key_list': ['test-object-1.txt', 'test-object-2.txt']
+}])
+def bucket_with_many_objects(request, s3_client):
+    # this fixture accepts an optional request.param['object_key_list'] with a list of custom key names
+    object_key_list = request.param['object_key_list']
+    # and a string prefix to prepend on all objects
+    object_prefix = request.param.get('object_prefix', "")
+
+    bucket_name = generate_unique_bucket_name(base_name='fixture-bucket-with-many-objects')
+    create_bucket_and_wait(s3_client, bucket_name)
+
+    content = b"Sample content for testing presigned URLs."
+    for object_key in object_key_list:
+        put_object_and_wait(s3_client, bucket_name, f"{object_prefix}{object_key}", content)
+
+    # Yield the bucket name and object details to the test
+    yield bucket_name, object_prefix, content
+
+    # Teardown: Delete the object and bucket after the test
+    for object_key in object_key_list:
+        delete_object_and_wait(s3_client, bucket_name, object_key)
+    delete_bucket_and_wait(s3_client, bucket_name)
+
+
 
 @pytest.fixture
 def bucket_with_one_storage_class_cold_object(s3_client, bucket_with_one_object):

--- a/docs/object_download_cli.py
+++ b/docs/object_download_cli.py
@@ -1,0 +1,62 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     name: s3-specs
+#     display_name: S3 Specs
+#   language_info:
+#     name: python
+# ---
+
+# # Download de Objeto utilizando a CLI MGC
+# 
+# O comando para o download de um objeto via mgc cli é o `object-storage objects download`
+# como exemplificado nos exemplos abaixo:
+
+commands = [
+    "{mgc_path} object-storage objects download '{bucket_name}/{object_key}' '{local_path}'",
+    "{mgc_path} os objects download '{bucket_name}/{object_key}' '{local_path}'",
+]
+
+# + {"jupyter": {"source_hidden": true}}
+import pytest
+import logging
+import subprocess
+from shlex import split
+from s3_helpers import (
+    run_example,
+)
+pytestmark = [pytest.mark.basic, pytest.mark.cli]
+# -
+
+# + tags=["parameters"]
+config = "../params/br-ne1.yaml"
+# -
+
+# +
+object_keys = [
+    "test-object.txt",
+    "test/object/sub/folder/😘 Arquivo com espaço e acentuação 🍕.txt",
+]
+test_cases = [
+    (command, {'object_key': object_key}) 
+    for command in commands
+    for object_key in object_keys
+]
+
+@pytest.mark.parametrize(
+    "cmd_template, bucket_with_one_object",
+    test_cases,
+    indirect=["bucket_with_one_object"]
+)
+def test_download_object_cli(cmd_template, bucket_with_one_object, active_mgc_workspace, mgc_path):
+    local_path = "/tmp/downloaded test file.txt"
+    bucket_name, object_key, content = bucket_with_one_object
+    cmd = split(cmd_template.format(mgc_path=mgc_path, bucket_name=bucket_name, object_key=object_key, local_path=local_path))
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    assert result.returncode == 0, f"Command failed with error: {result.stderr}"
+    logging.info(f"Output from {cmd_template}: {result.stdout}")
+
+run_example(__name__, "test_download_object_cli", config=config)
+# -

--- a/docs/objects_list_cli.py
+++ b/docs/objects_list_cli.py
@@ -1,0 +1,79 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     name: s3-specs
+#     display_name: S3 Specs
+#   language_info:
+#     name: python
+# ---
+
+# # Listagem de Objeto utilizando a CLI MGC
+# 
+# O comando para a listagem de objetos em um bucket via mgc cli é o `object-storage objects list`
+# junto com o nome do bucket é possivel incluir um prefixo, considerando que é comum ferramentas
+# de sync de diretórios usarem nomes de objetos em um formato de "path"
+# como nos exemplos abaixo:
+
+commands = [
+    "{mgc_path} object-storage objects list '{bucket_name}'",
+    "{mgc_path} os objects list '{bucket_name}/{object_prefix}'",
+]
+
+# + {"jupyter": {"source_hidden": true}}
+import pytest
+import logging
+import subprocess
+from shlex import split
+from s3_helpers import (
+    run_example,
+)
+pytestmark = [pytest.mark.basic, pytest.mark.cli]
+
+# -
+
+# + tags=["parameters"]
+config = "../params/br-ne1.yaml"
+# -
+
+# +
+
+test_buckets = [
+    {
+        "object_prefix": "",
+        "object_key_list": ["simple-object-key.txt"],
+    },
+    {
+        "object_prefix": "simple-prefix/",
+        "object_key_list": [ "sufix-1.txt", "sufix-2.txt", ]
+    },
+    {
+        "object_prefix": "prefix/with/multiple/slashes/",
+        "object_key_list": [
+            "acentuação e emojis 🎉 🥳 😘-1.txt",
+            "acentuação e emojis 😘 🎉 🥳-2.txt",
+        ]
+    },
+]
+
+test_cases = [
+    (command, test_bucket)
+    for command in commands
+    for test_bucket in test_buckets
+]
+
+@pytest.mark.parametrize(
+    "cmd_template, bucket_with_many_objects",
+    test_cases,
+    indirect=["bucket_with_many_objects"]
+)
+def test_list_objects_cli(cmd_template, bucket_with_many_objects, active_mgc_workspace, mgc_path):
+    bucket_name, object_prefix, _content = bucket_with_many_objects
+    cmd = split(cmd_template.format(mgc_path=mgc_path, bucket_name=bucket_name, object_prefix=object_prefix))
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    assert result.returncode == 0, f"Command failed with error: {result.stderr}"
+    logging.info(f"Output from {cmd_template}: {result.stdout}")
+
+run_example(__name__, "test_list_objects_cli", config=config)
+# -


### PR DESCRIPTION
> This patch adds a simple spec for the download object command of the MGC CLI.
> 
> The test cases includes object key names with special characteres, slashes (subpath) and spaces.

## Objetivo do PR
Este patch adiciona dois testes, um do comando `object-storage objects download` da CLI e um do comando `object-storage objects list`. Entre os casos de teste estão objetos com nomes contendo espaços, barras e caracteres especiais.

## Motivo do PR
Um cliente (a Kognita?) utilizando a mgc cli não consegui fazer ~download (get object) de objetos~ listagem de objetos (list objects) com espaço utilizando a MGC CLI.  

## Expectativa do PR
O objetivo deste PR é ter um teste que reproduz o problema em versoes antigas da cli, exemplo 0.34.0 e que este teste passe quando rodado em versoes mais recentes, evitando assim regressões no futuro.

## Link do Card no Kanban
[STK E610](https://kanban-force.web.app/boards/63d991aaf03baf6cfdc0f999?cardId=67bf26047fd136d6f729e610)