### PR TITLE
new task: browse

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ https://magalucloud.github.io/s3-specs/
 Install dependencies and launch a local Jupyter Lab server to view the specs interactively:
 
 ```bash
-uv run --with jupyter --with jupytext jupyter lab docs
+just browse
 ```
 
 Then, right-click a `_test.py` file and choose "Open With Notebook."

--- a/justfile
+++ b/justfile
@@ -27,3 +27,8 @@ categories:
 # List legacy categories (shellspec tags of legacy s3-tester)
 _legacy-categories:
   just utils extract_list "pyproject.toml" "tool.s3-tester" "markers"
+
+# Start a Jupyter lab server for browsing and executing the specs, right click and "Open as Notebook"
+browse:
+  uv run --with jupyter --with jupytext jupyter lab docs
+


### PR DESCRIPTION
This patch adds a new justfile recipe for launching the specs server, for people to read and execute the
specs in a web browser.

## Objetivo do PR

 Facilitar a vida de quem quiser ler a documentação de uma spec, bem como executá-la pelo navegador.

## Motivo do PR

Como parte do port dos testes legados do s3-tester para a casa nova, ter um atalho simples para subir o ambiente que renderiza os markdowns e que roda as specs via browser será útil como fluxo de trabalho, já que muitos testes antigos eram encarados apenas como código e não documentação. Neste processo de port já pretendo melhorar este lado dos testes serem especificações mesmo.

## Expectativa do PR

Espera-se que com um atalho listado nos comandos do just, outros contributors se interessem em ver localmente em suas máquinas como uma spec seria renderizada se/quando convertida para uma página de doc.

## Link do Card no Kanban

sem card, mas meio que parte do [STK-ED14](https://kanban-force.web.app/boards/63d991aaf03baf6cfdc0f999?cardId=67cef442c1f41ce0d73eed14)