### PR TITLE
new shortcut: just categories

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,9 @@
+# just submodule to store utility functions
+mod utils
+
 set shell := ["bash", "-cu"]
 
-@default:
+_default:
     just --list
 
 #Configure profiles in the CLI's
@@ -16,3 +19,11 @@ tests *pytest_params:
 report category:
     just setup-profiles
     bash -c "cd reports && ./run.sh {{category}} ../params.example.yaml ../docs/ && mv report_*.pdf outputs/"
+
+# List known categories (pytest markers)
+categories:
+  just utils extract_list "pyproject.toml" "tool.pytest.ini_options" "markers"
+
+# List legacy categories (shellspec tags of legacy s3-tester)
+_legacy-categories:
+  just utils extract_list "pyproject.toml" "tool.s3-tester" "markers"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,5 +58,21 @@ markers = [
     "slow: slow expected execution magnitude",
 ]
 
+[tool.s3-tester]
+markers = [
+  #"Benchmark",
+  "BigBuckets",
+  "BucketManagement",
+  "BucketPermission",
+  "BucketPolicy",
+  "BucketSharing",
+  "BucketTagging",
+  "ObjectLocking",
+  "ObjectManagement",
+  "ObjectVersioning",
+  "ColdStorage",
+  "ServiceAccounts",
+]
+
 [tool.uv.workspace]
 members = ["reports"]

--- a/utils.just
+++ b/utils.just
@@ -1,0 +1,12 @@
+# Generic list parsing that works on different sections of the toml file
+extract_list toml_file section list_name:
+  awk -v section="{{section}}" -v list_name="{{list_name}}" ' \
+  /^\[.*\]/ {in_section=($0 == "[" section "]") ? 1 : 0} \
+  in_section && $0 ~ ("^" list_name " = \\[") {in_list=1; next} \
+  in_list && /\]/ {in_list=0} \
+  in_list { \
+    line=$0; gsub(/^[ \t"]+|[" ,]+$/, "", line); \
+    if (line !~ /^#/) { if (line ~ /:/) sub(/:.*/, "", line); print line } \
+  }' {{toml_file}}
+
+


### PR DESCRIPTION
New justfile recipe to lists the available markers

## Objetivo do PR
Adiciona um atalho "just catefories" para listar os nomes das categorias disponíveis.

## Motivo do PR
Alguem que queira usar o comando report precisa saber quais as categorias disponiveis, este atalho lista sem que a pessoa precise abrir o pyproject.toml e ir lá fuçar

## Expectativa do PR
Uma experiencia mais simples para o dev contributor. Pode ser útil como input para outros comandos no futuro (um menu com fzf por exemplo)

## Link do Card no Kanban relacionado
[STK-ED14](https://kanban-force.web.app/boards/63d991aaf03baf6cfdc0f999?cardId=67cef442c1f41ce0d73eed14)