### PR TITLE
Test menu

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,19 +1,28 @@
-# just submodule to store utility functions
-mod utils
+# just file to store utility functions
+import './utils.just'
+
+# just module for TUI recipies
+mod menu
+
+# global variables
+s3_tester_image := "ghcr.io/magalucloud/s3-tester:tests"
 
 set shell := ["bash", "-cu"]
 
 _default:
-    just --list
+    @just --list
 
 #Configure profiles in the CLI's
 setup-profiles:
     uv run ./bin/configure_profiles.py ./params.example.yaml
 
+# Run the tests
+_run_tests config_file *pytest_params:
+    uv run pytest ./docs/*_test.py --config {{config_file}} {{pytest_params}}
+
 #Execute the tests of s3-specs
-tests *pytest_params:
-    just setup-profiles
-    uv run pytest ./docs/*_test.py --config ./params.example.yaml {{pytest_params}}
+tests *pytest_params: setup-profiles
+    just _run_tests "./params.example.yaml" {{pytest_params}}
 
 #Execute the tests of s3-specs and generate a report of the tests after running.
 report category:
@@ -22,13 +31,8 @@ report category:
 
 # List known categories (pytest markers)
 categories:
-  just utils extract_list "pyproject.toml" "tool.pytest.ini_options" "markers"
-
-# List legacy categories (shellspec tags of legacy s3-tester)
-_legacy-categories:
-  just utils extract_list "pyproject.toml" "tool.s3-tester" "markers"
+  just _extract_list "pyproject.toml" "tool.pytest.ini_options" "markers"
 
 # Start a Jupyter lab server for browsing and executing the specs, right click and "Open as Notebook"
 browse:
   uv run --with jupyter --with jupytext jupyter lab docs
-

--- a/menu.just
+++ b/menu.just
@@ -1,0 +1,47 @@
+_default:
+  just --list menu
+
+# TUI for picking multiple choice using fzf
+_menu_picker title:
+  fzf -m --header="{{title}} Tab=select, Enter=OK" --layout=reverse
+
+# TUI for free text input using fzf
+_text_prompt title default_value:
+  echo {{default_value}} | \
+  fzf --print-query --prompt="{{title}}" --layout=reverse | \
+  tail -n1
+
+# Interactively pick categories to test
+test config_file="./params.example.yaml":
+  #!/usr/bin/env bash
+  test_categories=$(just categories | just menu::_menu_picker \
+      "Select the categories to test")
+  just _run_tests {{config_file}} -m "$test_categories" 
+
+# Interactively pick legacy categories to test on s3-tester (soon to be deprecated)
+legacy-test:
+  #!/usr/bin/env bash
+  config_file=$(\
+    just menu::_text_prompt "Enter legacy config yaml file path: " "../s3-tester/profiles.yaml" \
+  )
+  profiles=$(\
+    just menu::_text_prompt "Enter comma separated list of profile names: " "br-ne1,br-se1" \
+  )
+  categories=$(\
+    just _legacy-categories | \
+    just menu::_menu_picker \
+      "Select the legacy categories to test on s3-tester" | \
+    paste -sd ',' -\
+  )
+  clients=$(\
+    echo -e "aws\nmgc\nrclone" | \
+    just menu::_menu_picker \
+      "Select the CLI clients" | \
+    paste -sd ',' -\
+  )
+
+  echo "Using Config File: $config_file"
+  echo "Using Profiles: $profiles"
+  echo "Selected Clients: $clients"
+  echo "Selected Categories: $categories"
+  just _legacy-tests "$config_file" "$profiles" "$clients" "$categories" podman

--- a/utils.just
+++ b/utils.just
@@ -1,5 +1,5 @@
 # Generic list parsing that works on different sections of the toml file
-extract_list toml_file section list_name:
+_extract_list toml_file section list_name:
   awk -v section="{{section}}" -v list_name="{{list_name}}" ' \
   /^\[.*\]/ {in_section=($0 == "[" section "]") ? 1 : 0} \
   in_section && $0 ~ ("^" list_name " = \\[") {in_list=1; next} \
@@ -9,4 +9,16 @@ extract_list toml_file section list_name:
     if (line !~ /^#/) { if (line ~ /:/) sub(/:.*/, "", line); print line } \
   }' {{toml_file}}
 
+# List legacy categories (shellspec tags of legacy s3-tester)
+_legacy-categories:
+  just _extract_list "pyproject.toml" "tool.s3-tester" "markers"
 
+# Run legacy s3-tester tests using docker or podman (oci_runner)
+@_legacy-tests config_file profiles clients categories oci_runner="docker":
+  echo Please run the following command:
+  echo {{oci_runner}} run -t \
+    -e PROFILES=\"\$\(cat {{config_file}}\)\" \
+    {{s3_tester_image}} test.sh \
+    --profiles {{profiles}} \
+    --clients {{clients}} \
+    --categories {{categories}}


### PR DESCRIPTION
## Objetivo do PR

Este PR tem o objetivo de facilitar a vida dos contributors deste repositório e usuários do s3-specs, por meio de uma interface de menu para interativamente selecionar categorias de testes, sejam das existentes no s3-specs ou das legadas do s3-tester. Dois novos comandos:

`just menu test`

e

`just menu legacy-test`


## Motivo do PR

A transição dos testes antigos, que tinham foco em ferramentas de CLI para dentro do pytest é algo que vai levar um tempo para ser feita com cuidado e gerando documentações executáveis no formato markdown/jupyter. Neste meio tempo, poder arquivar o repositório do s3-tester e focar o desenvolvimento só aqui é importante. Com este menu, podemos atualizar a HT de como rodar os testes para ter instrucoes que só dependem ou de comandos do s3-specs.

## Link do Card no Kanban
Relacionado a [STK-ED14](https://kanban-force.web.app/boards/63d991aaf03baf6cfdc0f999?cardId=67cef442c1f41ce0d73eed14)

## Nota para os Revisores

Esta branch depende desta outra: https://github.com/MagaluCloud/s3-specs/pull/75 que é bem simples de revisar, aprovem aquela primeiro.