### PR TITLE
Cli policy

### DIFF
--- a/docs/policy_cli_test.py
+++ b/docs/policy_cli_test.py
@@ -1,0 +1,240 @@
+# ---
+# jupyter:
+#   kernelspec:
+#     name: s3-specs
+#     display_name: S3 Specs
+#   language_info:
+#     name: python
+# ---
+
+# # Bucket Policy via MGC CLI
+#
+# Restringir determinadas ações passíveis de serem executadas em um bucket, ou
+# compartilhar acessos de leitura e escrita com outros usuários (Principals),
+# são exemplos de possibilidades que a funcionalidade de Bucket Policy (políticas
+# do conteiner) permitem.
+#
+# A configuração, remoção e atualização de políticas em um bucket, por documentos
+# de policy (arquivos JSON) pode ser feita via MGC CLI. Este é o assunto desta
+# especificação.
+#
+
+# + tags=["parameters"]
+config = "../params/br-ne1.yaml"
+# -
+
+# + {"jupyter": {"source_hidden": true}}
+import pytest
+import logging
+import json
+import subprocess
+from shlex import split
+from s3_helpers import (
+    run_example,
+)
+from utils.policy import fixture_bucket_with_policy
+pytestmark = [pytest.mark.basic, pytest.mark.cli]
+# -
+# ## Como fazer
+
+# ### Listar os comandos disponíveis
+#
+# O manual de uso com os comandos disponíveis na CLI relacionados a Bucket Policy
+# pode ser consultado via terminal usando o comando abaixo:
+
+commands = [
+    "{mgc_path} object-storage buckets policy --help",
+]
+
+# + {"jupyter": {"source_hidden": true}}
+
+@pytest.mark.parametrize("cmd_template", commands)
+def test_cli_help_policy(cmd_template, mgc_path):
+    cmd = split(cmd_template.format(mgc_path=mgc_path))
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    assert result.returncode == 0, f"Command failed with error: {result.stderr}"
+    logging.debug(f"Output from {cmd_template}: {result.stdout}")
+    assert all(snippet in result.stdout for snippet in ["delete", "get", "set"])
+
+run_example(__name__, "test_cli_help_policy", config=config)
+# -
+
+
+# ### Atribuir uma política a um bucket
+#
+# Para definir uma política de bucket usando a MGC CLI, utilize o comando:
+
+set_policy_commands = [
+    "{mgc_path} object-storage buckets policy set --dst {bucket_name} --policy '{policy_json_content}'",
+]
+
+# #### Sobre o Policy Document
+#
+# O argumento `--policy` deve receber uma string em formato JSON com o documento de policy,
+# abaixo um exemplo de policy simples, contendo uma única regra:
+
+# +
+valid_simple_policy = """{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": "<bucket_name>/*"
+        }
+    ]
+}"""
+# -
+
+# > **Nota:** Substitua `<bucket_name>` pelo nome do seu bucket.
+
+# Alguns exemplos para o valor do campo `Principal`:
+
+# +
+principal_examples = [
+    '"*"',
+    '{ "MGC": "320b11ea-4281-4dc5-9c41-cc3808dc5c91" }',
+    '{ "MGC": ["320b11ea-4281-4dc5-9c41-cc3808dc5c91", "6186fe6c-0a6d-41a1-883b-482ea3251cb8"] }',
+]
+# -
+
+# Alguns exemplos para o valor do campo `Action`:
+
+# +
+action_examples = [
+    '"s3:GetObject"',
+    '["s3:DeleteObject", "s3:GetObject"]',
+]
+# -
+
+# Alguns exemplos para o valor do campo `Resource`:
+
+# +
+resource_examples = [
+    '["<bucket_name>/ítem_➀", <bucket_name>/ítem_➁", "<bucket_name>/ítem_😘"]',
+    '"<bucket_name>/*"',
+    '"*/*"',
+    '["<bucket_name>/*"]',
+]
+# -
+# Alguns exemplos de actions que esperam bucket como resource junto com actions que esperam
+# objects como `Resource`:
+
+mixed_actions_examples = [
+    '["s3:ListBucket", "s3:GetObject"]',
+    '["s3:ListBucket", "s3:DeleteObject"]',
+]
+
+mixed_resources_examples = [
+    '["<bucket_name>", "<bucket_name>/*"]',
+    '["<bucket_name>", "<bucket_name>/object_key"]',
+]
+
+# + {"jupyter": {"source_hidden": true}}
+
+object_resource_policies = [
+    valid_simple_policy.replace('"*"', p).replace('"s3:GetObject"', a).replace('"<bucket_name>/*"', r)
+    for p in principal_examples
+    for a in action_examples
+    for r in resource_examples
+]
+object_and_bucket_resources_policies = [
+    valid_simple_policy.replace('"*"', p).replace('"s3:GetObject"', a).replace('"<bucket_name>/*"', r)
+    for p in principal_examples
+    for a in mixed_actions_examples
+    for r in mixed_resources_examples
+]
+policy_templates = object_resource_policies + object_and_bucket_resources_policies
+
+set_policy_testcases = [(cmd, policy) for cmd in set_policy_commands for policy in policy_templates]
+
+@pytest.mark.parametrize("cmd_template, policy_template", set_policy_testcases)
+def test_cli_set_policy(cmd_template, policy_template, active_mgc_workspace, mgc_path, existing_bucket_name):
+    bucket_name = existing_bucket_name
+    policy = policy_template.replace("<bucket_name>", bucket_name)
+    logging.info(policy)
+    cmd = split(cmd_template.format(
+        mgc_path=mgc_path,
+        bucket_name=bucket_name,
+        policy_json_content=policy
+    ))
+    logging.info(f"{cmd}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    assert result.returncode == 0, f"Command failed with error: {result.stderr}"
+    logging.info(f"Output from {cmd_template}: {result.stdout}")
+
+run_example(__name__, "test_cli_set_policy", config=config)
+# -
+
+# ### Consultar a política de um bucket
+#
+# Para consultar a política atual de um bucket usando a MGC CLI, utilize o comando `get`:
+
+get_policy_commands = [
+    "{mgc_path} object-storage buckets policy get --dst {bucket_name} --output=json --raw",
+]
+
+# + {"jupyter": {"source_hidden": true}}
+
+@pytest.mark.parametrize(
+    "cmd_template",
+    get_policy_commands,
+)
+def test_cli_get_policy(cmd_template, fixture_bucket_with_policy, active_mgc_workspace, mgc_path):
+    bucket_name, policy_doc, _s3_clients, _object_prefix, _content = fixture_bucket_with_policy
+    cmd = split(cmd_template.format(mgc_path=mgc_path, bucket_name=bucket_name))
+    logging.info(f"{cmd}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    assert result.returncode == 0, f"Command failed with error: {result.stderr}"
+    logging.info(f"Output from {cmd_template}: {result.stdout}")
+
+    expected_policy_data = json.loads(policy_doc)
+    returned_policy_data = json.loads(result.stdout)
+    for field_name in ['Resource', 'Effect', 'Principal']:
+        assert expected_policy_data.get('Statement')[0][field_name] == returned_policy_data.get('Statement')[0][field_name]
+
+
+run_example(__name__, "test_cli_get_policy", config=config)
+# -
+
+# ### Remover uma política de um bucket
+#
+# Para deletar uma política de bucket usando a MGC CLI, utilize o comando:
+
+delete_policy_commands = [
+    "{mgc_path} object-storage buckets policy delete --dst {bucket_name}",
+]
+
+# + {"jupyter": {"source_hidden": true}}
+
+@pytest.mark.parametrize(
+    "cmd_template",
+    delete_policy_commands,
+)
+def test_cli_delete_policy(cmd_template, fixture_bucket_with_policy, active_mgc_workspace, mgc_path):
+    bucket_name, _policy_doc, _s3_clients, _object_prefix, _content = fixture_bucket_with_policy
+    cmd = split(cmd_template.format(mgc_path=mgc_path, bucket_name=bucket_name))
+    logging.info(f"{cmd}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    assert result.returncode == 0, f"Command failed with error: {result.stderr}"
+    logging.info(f"Output from {cmd_template}: {result.stdout}")
+
+run_example(__name__, "test_cli_delete_policy", config=config)
+# -
+
+# ## Documentos relacionados
+#
+# Uma breve lista de outras referências sobre Bucket Policy
+#
+# - Docs Magalu Cloud: [Docs > Armazenamento > Object Storage > Como Fazer > Permissões > Bucket Policy](https://docs.magalu.cloud/docs/storage/object-storage/how-to/permissions/policies)
+# - Docs Magalu Cloud: [Docs > Armazenamento > Object Storage > Controle de Acesso de Dados > Bucket Policy](https://docs.magalu.cloud/docs/storage/object-storage/access-control/bucket_policy_overview/)
+# - s3-specs: [python/boto3 policies spec 1](https://magalucloud.github.io/s3-specs/runs/profiles_policies_test_br-ne1.html)
+# - s3-specs: [python/boto3 policies spec 2](https://magalucloud.github.io/s3-specs/runs/policies_test_test_br-ne1.html)
+# - s3-tester (specs legadas): [legacy s3-tester spec id:091](https://github.com/MagaluCloud/s3-tester/blob/main/spec/091_bucket-policy_spec.sh)
+# - AWS S3: [Bucket Policies for Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html)
+# - AWS S3: [Bucket policies](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-example-bucket-policies.html)

--- a/docs/s3_helpers.py
+++ b/docs/s3_helpers.py
@@ -108,12 +108,11 @@ def delete_all_objects_and_wait(s3_client, bucket_name):
         for obj in response['Contents']:
             delete_object_and_wait(s3_client, bucket_name, obj['Key'])
  
-def delete_policy_and_bucket_and_wait(s3_client, bucket_name, policy_wait_time, request):
+def delete_policy_and_bucket_and_wait(s3_client, bucket_name, policy_wait_time):
     retries = 3
     sleeptime = 5
     for attempt_number in range(retries):   
         try:
-            change_policies_json(bucket_name, {"policy_dict": request.param['policy_dict'], "actions": ["s3:GetObjects", "*"], "effect": "Allow"}, tenants=["*"])
             logging.info(f"deleting policy of bucket {bucket_name}...")
             s3_client.delete_bucket_policy(Bucket=bucket_name)
             break

--- a/docs/s3_helpers.py
+++ b/docs/s3_helpers.py
@@ -35,7 +35,8 @@ def run_example(dunder_name, test_name, config="../params.example.yaml"):
             "--color", "no", 
             "--pytest-durations", "0",
             # "-s", 
-            # "--log-cli-level", "INFO",
+            # "-x",
+            "--log-cli-level", "INFO",
             f"{get_spec_path()}::{test_name}"
         ])
  
@@ -256,12 +257,13 @@ def change_policies_json(bucket, policy_args: dict, tenants: list) -> json:
     policy = policy_args['policy_dict']
     effect = policy_args['effect']
     actions = policy_args['actions']
+    object_key = policy_args.get("resource_key", "*")
     
     #change arguments inside of the policy dict
     policy["Statement"][0]["Effect"] = effect
     policy["Statement"][0]["Principal"] = tenants
     policy["Statement"][0]["Action"] = actions
-    policy["Statement"][0]["Resource"] = [bucket + "/*", bucket]
+    policy["Statement"][0]["Resource"] = [f"{bucket}/{object_key}", bucket]
         
     logging.info(f"POLICY: {json.dumps(policy)}")
     return json.dumps(policy)

--- a/docs/utils/policy.py
+++ b/docs/utils/policy.py
@@ -1,0 +1,38 @@
+import logging
+import pytest
+
+allow_get_object_policy = """{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": "<bucket_name>/*"
+        }
+    ]
+}"""
+
+
+# This fixture accepts indirect arguments in a dict:
+#   policy_doc: is a string with a json and <bucket_name>
+# on the places that will be replaced with the name
+# of the generated bucket
+#
+# This fixture depends on the bucket_with_many_objects
+# fixture so if your test needs custom object keys you
+# need to indirect pass the arguments for that dependency
+#
+# This fixture depends on the multiple_s3_clients
+# fixture so if your test needs custom number of clients you
+# need to indirect pass the arguments for that dependency
+@pytest.fixture(params=[{'policy_doc': allow_get_object_policy}])
+def fixture_bucket_with_policy(request, multiple_s3_clients, bucket_with_many_objects):
+    s3_clients = multiple_s3_clients
+    bucket_owner_client = s3_clients[0]
+    bucket_name, object_prefix, content = bucket_with_many_objects
+    policy_template = request.param['policy_doc']
+    policy_doc = policy_template.replace("<bucket_name>", bucket_name)
+    bucket_owner_client.put_bucket_policy(Bucket=bucket_name, Policy = policy_doc)
+
+    return bucket_name, policy_doc, s3_clients, object_prefix, content

--- a/params.example.yaml
+++ b/params.example.yaml
@@ -2,11 +2,11 @@ docs_dir: "."
 default_profile_index: 0
 profiles:
   -
-    profile_name: "br-se1"
-    policy_wait_time: 120
+    profile_name: "br-ne1"
+    policy_wait_time: 0
   -
-    profile_name: "br-se1-second"
-    policy_wait_time: 120
+    profile_name: "br-ne1-second"
+    policy_wait_time: 0
   -
     profile_name: "br-ne1"
   -


### PR DESCRIPTION
## Objetivo do PR

Nova spec documentando como usar bucket policy com a CLI MGC.

## Motivo do PR

Nossas docs (specs) que dizem respeito a bucket policy hoje utilizam apenas a lib boto3 nos exemplos.
Como parte do esforço de migração dos testes de CLI do antigo shellspec (s3-tester) para o Pytest (s3-specs), este patch traz exemplos de uso da cli equivalentes aos de mgc presentes na antiga spec 84.

## Expectativa do PR

Termos exemplos funcionais do uso de bucket policy via CLI.

## Link do Card no Kanban
[STK-ED14](https://kanban-force.web.app/boards/63d991aaf03baf6cfdc0f999?cardId=67cef442c1f41ce0d73eed14)