### PR TITLE
(oci, full) Install just task runner from installation script

### DIFF
--- a/.github/workflows/full-docker-image.yml
+++ b/.github/workflows/full-docker-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - recent-just-oci
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: magalucloud/s3-specs

--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ _run_tests config_file *pytest_params:
 
 #Execute the tests of s3-specs
 tests *pytest_params: setup-profiles
-    just _run_tests "./params.example.yaml" {{pytest_params}}
+    just _run_tests "./params.example.yaml" "{{pytest_params}}"
 
 #Execute the tests of s3-specs and generate a report of the tests after running.
 report category:

--- a/menu.just
+++ b/menu.just
@@ -15,8 +15,8 @@ _text_prompt title default_value:
 test config_file="./params.example.yaml":
   #!/usr/bin/env bash
   test_categories=$(just categories | just menu::_menu_picker \
-      "Select the categories to test")
-  just _run_tests {{config_file}} -m "$test_categories" 
+      "Select the categories to test" | sed ':a;N;$!ba;s/\n/ or /g')
+  just _run_tests {{config_file}} "-m '$test_categories'" 
 
 # Interactively pick legacy categories to test on s3-tester (soon to be deprecated)
 legacy-test:

--- a/oci/full.Containerfile
+++ b/oci/full.Containerfile
@@ -7,6 +7,7 @@
 ARG AWS_CLI_VERSION="2.15.27"
 ARG RCLONE_VERSION="1.66.0"
 ARG MGC_VERSION="0.34.1"
+ARG JUST_VERSION="1.40.0"
 
 # aws-cli
 FROM public.ecr.aws/aws-cli/aws-cli:${AWS_CLI_VERSION} as awscli
@@ -19,7 +20,7 @@ RUN apt-get update && \
     unzip \
     python3 \
     git \
-    just;
+    fzf;
 
 # directory to download binaries
 RUN mkdir -p /tools;
@@ -47,6 +48,10 @@ RUN curl -Lo mgc.tar.gz "https://github.com/MagaluCloud/mgccli/releases/download
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     ln -s $HOME/.local/bin/uv /usr/local/bin/uv;
 
+# just (task runner, justfile)
+ARG JUST_VERSION
+RUN curl -LsSf https://just.systems/install.sh | bash -s -- --tag ${JUST_VERSION} --to /usr/local/bin;
+
 # container workdir
 WORKDIR /app
 
@@ -55,6 +60,7 @@ COPY bin /app/bin/
 COPY params.example.yaml /app/params.example.yaml
 COPY justfile /app/justfile
 COPY utils.just /app/utils.just
+COPY menu.just /app/menu.just
 COPY uv.lock /app/uv.lock
 COPY pyproject.toml /app/pyproject.toml
 COPY README.md /app/README.md
@@ -64,4 +70,4 @@ COPY reports /app/reports/
 RUN uv sync
 
 # Definir o script como ponto de entrada
-ENTRYPOINT ["just", "--justfile", "/app/justfile"]
+ENTRYPOINT ["just"]


### PR DESCRIPTION
The version on ubuntu apt packages dont have support for modules this patch makes the installation of the just task manager on our OCI Image configurable to use an specific version.

## Objetivo do PR
Arrumar erros causados na utilização das imagens de docker depois que o justfile com modulo de menu entrou..

## Motivo do PR
Nossa imagem de docker utilizava uma versao mais antiga do just, sem suporte a modulos e isto quebrava a experiencia de rodar os testes via conteiner.

## Expectativa do PR
Arrumar o uso do projeto via oci image.

## Link do Card no Kanban
Sem card