### PR TITLE
FIX: Dataclasses fixing

### DIFF
--- a/bin/exporter.py
+++ b/bin/exporter.py
@@ -5,6 +5,22 @@ import time
 import glob
 import os
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--parquet_path',
+                    required=True, 
+                    help='Path of folder containing the execution_time and test parquet artifacts')
+
+
+args = parser.parse_args()
+
+
+paths = {
+    'report_folder': './output/',
+    'grouped_file': './output/resultado_grouped.csv',
+    'inconsistencies_file': './output/report_inconsistencies.csv',
+    'benchmark_file': './output/benchmark_results.csv',
+}
+
 # Definir as métricas Gauge
 objs_consistency_time = Gauge(
     'objs_consistency_time',

--- a/docs/benchmark_test.py
+++ b/docs/benchmark_test.py
@@ -92,7 +92,7 @@ def test_benchmark(
                 os.makedirs("report", exist_ok=True)
                 
                 # Caminho do arquivo de relatório
-                report_file = "report/benchmark_results.csv"
+                report_file = "output/benchmark_results.csv"
                 
                 time_taken = measure_time(cmd)
                 subprocess.run(f"rm -rf temp-down-*", shell=True)

--- a/docs/consistency_test.py
+++ b/docs/consistency_test.py
@@ -167,5 +167,5 @@ def test_object_validations(setup_standard_bucket, setup_versioned_bucket, comma
     elapsed_time = end_time - start_time
 
     # Salva os resultados
-    with open('./report/report-inconsistencies.csv', 'a') as f:
+    with open('output/report_inconsistencies.csv', 'a') as f:
         f.write(f"{quantity},{workers},{command}_after_put,{profile_name},{bucket_type},{elapsed_time}\n")

--- a/output/benchmark_results.csv
+++ b/output/benchmark_results.csv
@@ -1,0 +1,1 @@
+region,tool,size,times,workers,quantity,operation,time

--- a/output/report_inconsistencies.csv
+++ b/output/report_inconsistencies.csv
@@ -1,0 +1,1 @@
+quantity,workers,command,region,bucket_state,elapsed


### PR DESCRIPTION
## Objetivo do PR
FIX: Resolver um problema que surgia ao executar a criacao de dataclasses entity_time e failures

## Motivo do PR
FIX: Implementar mudanca nos dataframes gerados para tornar as dataclasses armazenadas compativel com o webscrapping presente no file exporter.py

## Expectativa do PR
Corrigir o bug descrito e permitir a integração com o api utilizada

## Link do Card no Kanban
[[Link para o card no Kanban](URL_DO_CARD)](https://kanban-force.web.app/boards/63d991aaf03baf6cfdc0f999)