### PR TITLE
Processed workflow tracker

### DIFF
--- a/bin/exporter.py
+++ b/bin/exporter.py
@@ -173,7 +173,6 @@ def test_metrics_exporter():
             status=row['status']
         ).inc(1)
 
-
     print("Test metrics exported...")
 
 if __name__ == '__main__':

--- a/bin/exporter.py
+++ b/bin/exporter.py
@@ -37,13 +37,13 @@ avg_gauge = Gauge(
 execution_time_gauge = Gauge(
     's3_specs_time_metrics', 
     'Tests time metrics',  
-    ['execution_name', 'execution_type', 'category', 'time_metric']  
+    ['execution_name', 'execution_type', 'category','time_metric']  
 )
 
 execution_status_counter = Counter(
     's3_specs_status_counter',
     'Counter containing the number of status ocurrences on the recurrent testing',
-    ['name', 'status', 'category'],
+    ['name', 'status', 'category']
 )
 
 def read_csv_and_update_metrics():
@@ -164,17 +164,17 @@ def test_metrics_exporter():
     
     # Convert status to more readable labels if needed
     cleaned_status_df['status'] = cleaned_status_df['status'].map(status_mapping)
-    
-    # Group by name, category, and status to count occurrences
-    status_counts = cleaned_status_df.groupby(['name', 'category', 'status']).size().reset_index(name='count')
 
     # Increment the counter for each status occurrence
-    for _, row in status_counts.iterrows():
+    for _, row in cleaned_status_df.iterrows():
         execution_status_counter.labels(
             name=row['name'],
             category=row['category'],
             status=row['status']
-        ).inc(row['count'])
+        ).inc(1)
+
+
+    print("Test metrics exported...")
 
 if __name__ == '__main__':
     start_http_server(8000)

--- a/reports/src/git_local_extractor.py
+++ b/reports/src/git_local_extractor.py
@@ -66,9 +66,9 @@ def get_action_artifacts(repo_owner: str, repo_name: str, n: int, token: str, sa
 
         runs = list(map(lambda id: str(id['id']), response.json()['workflow_runs']))
         # Extraindo dados e achando os workflows que ainda nao foram processados
-        processed_workflow = list(set(runs).difference(set(processed)))
+        unprocessed_workflow = list(set(runs).difference(set(processed)))
 
-        for run_id in processed_workflow:
+        for run_id in unprocessed_workflow:
             print(f"Obtendo artefatos da execução do workflow: {run_id}")
             
             # URL para pegar os artefatos da execução do workflow


### PR DESCRIPTION
## Categoria do PR? 

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimização
- [ ] Documentação
- [ ] Testes

## Motivação do PR
Monitorar quais workflows ja foram processados para evitar dados redundantes.
Fix  nos valores do counter, pois, 
## Descrição do PR
Mudanca de counter do s3_specs counter para aumentar em 1 unidade ao inves de n a cada run.
Adicionada funcao que salva os id dos workflows ja processados

## [Opcional] Tickets, documentos ou outros dados relevantes

## [Opcional] Alguma necessidade de adaptação post deployment?

## Link do Card no Kanban
[[Link para o card no Kanban](URL_DO_CARD)](https://kanban-force.web.app/boards/67b35352a198404105930ec0?cardId=67e15646bf4f92bdb29100f2)