### PR TITLE
feat: add region flag to change region and endpoint dinamically

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -22,7 +22,7 @@ on:
           description: 'Version of the MGC CLI'
           default: '0.34.0'
           required: false
-        region:
+        profile:
           description: 'Region to use for the tests'
           default: 'br-se1'
           required: false
@@ -36,6 +36,6 @@ jobs:
       flags: ${{ inputs.flags }}
       runner: ${{ inputs.runner }}
       mgc_version: ${{ inputs.mgc_version }}
-      region: ${{ inputs.region }}
+      profile: ${{ inputs.profile }}
     secrets:
       PROFILES: ${{ secrets.PROFILES }}

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -22,7 +22,10 @@ on:
           description: 'Version of the MGC CLI'
           default: '0.34.0'
           required: false
-
+        region:
+          description: 'Region to use for the tests'
+          default: 'br-se1'
+          required: false
 jobs:
   run-tests:
     uses: ./.github/workflows/run-tests.yml
@@ -33,5 +36,6 @@ jobs:
       flags: ${{ inputs.flags }}
       runner: ${{ inputs.runner }}
       mgc_version: ${{ inputs.mgc_version }}
+      region: ${{ inputs.region }}
     secrets:
       PROFILES: ${{ secrets.PROFILES }}

--- a/.github/workflows/recurrent-tests.yml
+++ b/.github/workflows/recurrent-tests.yml
@@ -12,6 +12,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        region:
+          - br-se1
+          - br-ne1
         marker:
           # 1h tests
           - test: basic
@@ -27,6 +30,7 @@ jobs:
     with:
       name: "${{ matrix.marker.name }}_1hours.${{ matrix.config.name }}"
       config: ${{ matrix.config.path }}
+      region: ${{ matrix.region }}
       flags: "--no-header -vv -n auto --tb=line --color=no -m ${{ matrix.marker.test }} --tb=line"
     secrets:
       PROFILES: ${{ secrets.PROFILES }}
@@ -36,6 +40,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        region:
+          - br-se1
+          - br-ne1
         marker:
             # 6h tests
           - test: acl
@@ -53,6 +60,7 @@ jobs:
     with:
       name: "${{ matrix.marker.name }}_6hours.${{ matrix.config.name }}"
       config: ${{ matrix.config.path }}
+      region: ${{ matrix.region }}
       flags: "--no-header -vv -n auto --tb=line --color=no -m ${{ matrix.marker.test }} --tb=line"
     secrets:
       PROFILES: ${{ secrets.PROFILES }}
@@ -62,6 +70,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        region:
+          - br-se1
+          - br-ne1
         marker:
            # 12h tests
           - test: multiple_objects
@@ -75,6 +86,7 @@ jobs:
     with:
       name: "${{ matrix.marker.name }}_12hours.${{ matrix.config.name }}"
       config: ${{ matrix.config.path }}
+      region: ${{ matrix.region }}
       flags: "--no-header -vv -n auto --tb=line --color=no -m ${{ matrix.marker.test }} --tb=line"
     secrets:
       PROFILES: ${{ secrets.PROFILES }}

--- a/.github/workflows/recurrent-tests.yml
+++ b/.github/workflows/recurrent-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        region:
+        profile:
           - br-se1
           - br-ne1
         marker:
@@ -30,7 +30,7 @@ jobs:
     with:
       name: "${{ matrix.marker.name }}_1hours.${{ matrix.config.name }}"
       config: ${{ matrix.config.path }}
-      region: ${{ matrix.region }}
+      profile: ${{ matrix.profile }}
       flags: "--no-header -vv -n auto --tb=line --color=no -m ${{ matrix.marker.test }} --tb=line"
     secrets:
       PROFILES: ${{ secrets.PROFILES }}
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        region:
+        profile:
           - br-se1
           - br-ne1
         marker:
@@ -60,7 +60,7 @@ jobs:
     with:
       name: "${{ matrix.marker.name }}_6hours.${{ matrix.config.name }}"
       config: ${{ matrix.config.path }}
-      region: ${{ matrix.region }}
+      profile: ${{ matrix.profile }}
       flags: "--no-header -vv -n auto --tb=line --color=no -m ${{ matrix.marker.test }} --tb=line"
     secrets:
       PROFILES: ${{ secrets.PROFILES }}
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        region:
+        profile:
           - br-se1
           - br-ne1
         marker:
@@ -86,7 +86,7 @@ jobs:
     with:
       name: "${{ matrix.marker.name }}_12hours.${{ matrix.config.name }}"
       config: ${{ matrix.config.path }}
-      region: ${{ matrix.region }}
+      profile: ${{ matrix.profile }}
       flags: "--no-header -vv -n auto --tb=line --color=no -m ${{ matrix.marker.test }} --tb=line"
     secrets:
       PROFILES: ${{ secrets.PROFILES }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ on:
         flags: { required: true, type: string }
         runner: { required: false, type: string, default: "ubuntu-24.04" }
         mgc_version: { required: false, type: string, default: "0.34.0" }
-        region: { required: false, type: string, default: "br-se1" }
+        profile: { required: false, type: string, default: "br-se1" }
       secrets:
         PROFILES: { required: true }
 jobs:
@@ -64,7 +64,7 @@ jobs:
               run: |
                 cd src/s3_specs/docs
                 mkdir -p /s3-specs/artifact/
-                uv run pytest ${{inputs.tests}}  --config ${{ inputs.config }} --region ${{ inputs.region }} ${{ inputs.flags }} | tee /s3-specs/artifact/actions_pytest_output_${{ steps.format_name.outputs.formatted_log_name }}.log
+                uv run pytest ${{inputs.tests}}  --config ${{ inputs.config }} --profile ${{ inputs.profile }} ${{ inputs.flags }} | tee /s3-specs/artifact/actions_pytest_output_${{ steps.format_name.outputs.formatted_log_name }}.log
       
             - name: Upload Artifact
               uses: actions/upload-artifact@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,7 +64,7 @@ jobs:
               run: |
                 cd src/s3_specs/docs
                 mkdir -p /s3-specs/artifact/
-                uv run pytest${{inputs.tests}}  --config ${{ inputs.config }} --region ${{ inputs.region }} ${{ inputs.flags }} | tee /s3-specs/artifact/actions_pytest_output_${{ steps.format_name.outputs.formatted_log_name }}.log
+                uv run pytest ${{inputs.tests}}  --config ${{ inputs.config }} --region ${{ inputs.region }} ${{ inputs.flags }} | tee /s3-specs/artifact/actions_pytest_output_${{ steps.format_name.outputs.formatted_log_name }}.log
       
             - name: Upload Artifact
               uses: actions/upload-artifact@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,6 +9,7 @@ on:
         flags: { required: true, type: string }
         runner: { required: false, type: string, default: "ubuntu-24.04" }
         mgc_version: { required: false, type: string, default: "0.34.0" }
+        region: { required: false, type: string, default: "br-se1" }
       secrets:
         PROFILES: { required: true }
 jobs:
@@ -63,7 +64,7 @@ jobs:
               run: |
                 cd src/s3_specs/docs
                 mkdir -p /s3-specs/artifact/
-                uv run pytest --config ${{ inputs.config }} ${{inputs.tests}} ${{ inputs.flags }} | tee /s3-specs/artifact/actions_pytest_output_${{ steps.format_name.outputs.formatted_log_name }}.log
+                uv run pytest${{inputs.tests}}  --config ${{ inputs.config }} --region ${{ inputs.region }} ${{ inputs.flags }} | tee /s3-specs/artifact/actions_pytest_output_${{ steps.format_name.outputs.formatted_log_name }}.log
       
             - name: Upload Artifact
               uses: actions/upload-artifact@v4

--- a/src/s3_specs/docs/conftest.py
+++ b/src/s3_specs/docs/conftest.py
@@ -30,7 +30,7 @@ from botocore.exceptions import ClientError
 
 def pytest_addoption(parser):
     parser.addoption("--config", action="store", help="Path to the YAML config file")
-    parser.addoption("--region", action="store", help="Region to use for the tests")
+    parser.addoption("--profile", action="store", help="profile to use for the tests")
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -47,18 +47,16 @@ def test_params(request):
     """
     config_path = request.config.getoption("--config") or os.environ.get("CONFIG_PATH", "../params.example.yaml")
     
-    region = request.config.getoption("--region") or os.environ.get("REGION", None)
-    logging.info(f"Region: {region}")
+    profile = request.config.getoption("--profile") or os.environ.get("PROFILE", None)
+    logging.info(f"Region: {profile}")
     with open(config_path, "r") as f:
         config = yaml.safe_load(f)
-        if not region:
+        if not profile:
             return config
-        sufix = ["", "second", "third"]
-        for index, profile in enumerate(config["profiles"]):
-            if "profile_name" in profile:
-                profile["profile_name"] = f"{region}-{sufix[index]}"
-            profile["region_name"] = region
-            profile["endpoint_url"] = f"https://{region}.magaluobjects.com/"
+        sufix = ["", "-second", "-third"]
+        for index, profile_index in enumerate(config["profiles"]):
+            if "profile_name" in profile_index and index < 3:
+                profile_index["profile_name"] = f"{profile}{sufix[index]}"
         
         logging.info(f"Config: {config}")
         return config


### PR DESCRIPTION
## Categoria do PR? 

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimização
- [ ] Documentação
- [ ] Testes

## Motivação do PR
Poder trocar a região e o endpoint url de forma fácil

## Descrição do PR
    Adicionei a flag custom --region no pytest onde eu passo a região que quero rodar os testes (br-se1, br-se1-yel, br-ne1, br-ne1-yel) e os valores dos endpoints e region é alterado dinamicamente de acordo com o valor passado em --region.
