### PR TITLE
Fix GitHub Action to fail when pytest tests fail

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -60,6 +60,7 @@ jobs:
                   echo "formatted_log_name=$FORMATTED_NAME.$(date +'%Y%m%dT%H%M%S')" >> "$GITHUB_OUTPUT"
 
             - name: Run tests ${{ inputs.name }}
+              shell: bash
               run: |
                 cd src/s3_specs/docs
                 mkdir -p /s3-specs/artifact/

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -63,6 +63,7 @@ jobs:
               run: |
                 cd src/s3_specs/docs
                 mkdir -p /s3-specs/artifact/
+                set -o pipefail
                 uv run pytest --config ${{ inputs.config }} ${{inputs.tests}} ${{ inputs.flags }} | tee /s3-specs/artifact/actions_pytest_output_${{ steps.format_name.outputs.formatted_log_name }}.log
       
             - name: Upload Artifact


### PR DESCRIPTION
## Categoria do PR? 

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimização
- [ ] Documentação
- [ ] Testes

## Motivação do PR
Erros sendo mascarados pelo github actions

## Descrição do PR
    Devido a alguma alteração realizada no workflow do github, os testes passaram a se mostrar como se tivesse tido sucesso, mesmo estando com erros.

## Link do Card no Kanban
[Link para o card no Kanban](URL_DO_CARD)