### PR TITLE
feat: add tags for dev and homologacao

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ custom-mgc/*
 
 params.yaml
 
+temp*
+
 # Ignore any output folder created on run time
 **output/*.parquet
 output/processed.csv

--- a/justfile
+++ b/justfile
@@ -46,6 +46,10 @@ test test_name *pytest_params: setup-profiles
 dev *pytest_params: setup-profiles
     just _run_dev_tests {{pytest_params}}
 
+#Execute homologation tests
+homologate *pytest_params: setup-profiles
+    just _run_tests_with_report homologacao
+
 # List known categories (pytest markers)
 categories:
   just _extract_list "pyproject.toml" "tool.pytest.ini_options" "markers"

--- a/justfile
+++ b/justfile
@@ -18,13 +18,18 @@ setup-profiles:
 
 # Run the tests
 _run_tests config_file *pytest_params:
-    uv run pytest ./src/s3_specs/docs/*_test.py --config {{config_file}} {{pytest_params}}
+    uv run pytest ./src/s3_specs/docs/ --config {{config_file}} {{pytest_params}}
 
 _run_tests_with_report category mark = "''":
     uv run python3 run_tests_and_generate_report.py {{category}} --mark {{mark}}
 
+_run_specific_test_file config_file test_name *pytest_params:
+    uv run pytest ./src/s3_specs/docs/{{test_name}} --config {{config_file}} {{pytest_params}}
 
-#Execute the tests of s3-specs
+_run_dev_tests *pytest_params:
+    uv run pytest ./src/s3_specs/docs/ --config ./params.example.yaml -m '(not consistency) and (not benchmark)' {{pytest_params}} --run-dev 
+
+#Execute the tests of s3-specs generating reports
 tests category mark = "" : setup-profiles
     # just _run_tests "./params.example.yaml" 
     just _run_tests_with_report {{category}} {{mark}}
@@ -32,6 +37,14 @@ tests category mark = "" : setup-profiles
 #Execute the tests of s3-specs using pytest
 tests-pytest *pytest_params: setup-profiles
     just _run_tests "./params.example.yaml" {{pytest_params}}
+
+#Execute a specific test of s3-specs
+test test_name *pytest_params: setup-profiles
+    just _run_specific_test_file "./params.example.yaml" {{test_name}} {{pytest_params}}
+
+#Execute test in dev mode
+dev *pytest_params: setup-profiles
+    just _run_dev_tests {{pytest_params}}
 
 # List known categories (pytest markers)
 categories:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ env = ["JUPYTER_PLATFORM_DIRS=1"]
 addopts = "--json-report --json-report-file=reports/report.json --html=reports/report.html --self-contained-html"
 markers = [
     "only_run_in_region(regions): Only run the test in a specific region",
+    "skip_if_dev: Skip the tests if running as dev",
     "acl: Canned ACL (access control list)",
     "locking: Bucket Lock configuration and Object lock retention",
     "policy: Bucket Policy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ addopts = "--json-report --json-report-file=reports/report.json --html=reports/r
 markers = [
     "only_run_in_region(regions): Only run the test in a specific region",
     "skip_if_dev: Skip the tests if running as dev",
+    "homologacao: Run tests used in homologation",
     "acl: Canned ACL (access control list)",
     "locking: Bucket Lock configuration and Object lock retention",
     "policy: Bucket Policy",

--- a/run_tests_and_generate_report.py
+++ b/run_tests_and_generate_report.py
@@ -8,6 +8,7 @@ from report_generators import generate_pdf_report, create_index_html
 
 CATEGORY_MAPPING = {
     'full': '',
+    'homologacao': 'homologacao',
     'acl': 'acl',
     'locking': 'locking',
     'policy': 'policy',

--- a/src/s3_specs/docs/acl_test.py
+++ b/src/s3_specs/docs/acl_test.py
@@ -12,7 +12,7 @@ from botocore.exceptions import ClientError
 from s3_specs.docs.s3_helpers import update_existing_keys
 import logging
 
-pytestmark = [pytest.mark.acl, pytest.mark.skip_if_dev]
+pytestmark = [pytest.mark.acl, pytest.mark.skip_if_dev, pytest.mark.homologacao]
 
 # # OBJECT ACL
 

--- a/src/s3_specs/docs/acl_test.py
+++ b/src/s3_specs/docs/acl_test.py
@@ -12,7 +12,7 @@ from botocore.exceptions import ClientError
 from s3_specs.docs.s3_helpers import update_existing_keys
 import logging
 
-pytestmark = pytest.mark.acl
+pytestmark = [pytest.mark.acl, pytest.mark.skip_if_dev]
 
 # # OBJECT ACL
 

--- a/src/s3_specs/docs/benchmark_test.py
+++ b/src/s3_specs/docs/benchmark_test.py
@@ -4,6 +4,8 @@ import subprocess
 import pytest
 import tempfile
 
+pytestmark = [pytest.mark.skip_if_dev]
+
 # Função para medir o tempo de uma operação em millisegundos
 def measure_time(command):
     t0 = datetime.now()

--- a/src/s3_specs/docs/big_objects_cli.py
+++ b/src/s3_specs/docs/big_objects_cli.py
@@ -10,7 +10,7 @@ import os
 
 config = "../params/br-se1.yaml"
 
-pytestmark = [pytest.mark.big_objects, pytest.mark.cli]
+pytestmark = [pytest.mark.big_objects, pytest.mark.cli, pytest.mark.skip_if_dev]
 
 
 size_list = [

--- a/src/s3_specs/docs/big_objects_test.py
+++ b/src/s3_specs/docs/big_objects_test.py
@@ -7,6 +7,7 @@ import uuid
 from tqdm import tqdm
 import os
 
+pytestmark = [pytest.mark.skip_if_dev]
 
 size_list = [
     {'size': 10, 'unit': 'mb'},

--- a/src/s3_specs/docs/bucket_basic_test.py
+++ b/src/s3_specs/docs/bucket_basic_test.py
@@ -25,7 +25,7 @@ import secrets
 import uuid
 import botocore
 
-pytestmark = pytest.mark.basic
+pytestmark = [pytest.mark.basic, pytest.mark.homologacao]
 config = os.getenv("CONFIG", config)
 # -
 

--- a/src/s3_specs/docs/bucket_basic_test.py
+++ b/src/s3_specs/docs/bucket_basic_test.py
@@ -102,7 +102,8 @@ run_example(__name__, "test_create_bucket_invalid_name", config=config)
 @pytest.mark.parametrize("multiple_s3_clients, client_index", [
     ({"number_clients": 2}, 0),
     ({"number_clients": 2}, 1),
-], indirect=["multiple_s3_clients"]) 
+], indirect=["multiple_s3_clients"])
+@pytest.mark.skip_if_dev
 def test_create_bucket_duplicate(multiple_s3_clients, existing_bucket_name, client_index):
     logging.info(existing_bucket_name)
     sessions = multiple_s3_clients

--- a/src/s3_specs/docs/bucket_sharing_cli.py
+++ b/src/s3_specs/docs/bucket_sharing_cli.py
@@ -45,7 +45,7 @@ import requests
 import re
 
 # + {"tags": ["parameters"]}[
-pytestmark = [pytest.mark.bucket_sharing, pytest.mark.presign]
+pytestmark = [pytest.mark.bucket_sharing, pytest.mark.presign, pytest.mark.homologacao]
 config = "../params/br-ne1.yaml"
 
 

--- a/src/s3_specs/docs/bucket_sharing_test.py
+++ b/src/s3_specs/docs/bucket_sharing_test.py
@@ -43,7 +43,7 @@ import yaml
 from pathlib import Path
 from s3_specs.docs.s3_helpers import run_example
 
-pytestmark = [pytest.mark.bucket_sharing, pytest.mark.presign]
+pytestmark = [pytest.mark.bucket_sharing, pytest.mark.presign, pytest.mark.homologacao]
 config = os.getenv("CONFIG", config)
 
 def get_second_profile_boto3_client(profile_name, service='s3'):

--- a/src/s3_specs/docs/cold_storage_cli.py
+++ b/src/s3_specs/docs/cold_storage_cli.py
@@ -14,7 +14,7 @@ import uuid # For unique object keys
 config = "../params/br-se1.yaml"
 
 # + {"jupyter": {"source_hidden": true}}
-pytestmark = [pytest.mark.cold_storage, pytest.mark.cli, pytest.mark.only_run_in_region("br-se1")]
+pytestmark = [pytest.mark.cold_storage, pytest.mark.homologacao, pytest.mark.cli, pytest.mark.only_run_in_region("br-se1")]
 config = "../params/br-se1.yaml"
 
 storage_classes_list = [

--- a/src/s3_specs/docs/cold_storage_test.py
+++ b/src/s3_specs/docs/cold_storage_test.py
@@ -46,7 +46,7 @@ from s3_specs.docs.s3_helpers import run_example
 from botocore.exceptions import ClientError
 from s3_specs.docs.utils.cold_storage import fixture_multipart_upload_cold, calculate_checksum_fixture
 
-pytestmark = [pytest.mark.cold_storage, pytest.mark.cli, pytest.mark.only_run_in_region("br-se1")]
+pytestmark = [pytest.mark.cold_storage, pytest.mark.homologacao, pytest.mark.cli, pytest.mark.only_run_in_region("br-se1")]
 # -
 
 # ## Exemplos

--- a/src/s3_specs/docs/conftest.py
+++ b/src/s3_specs/docs/conftest.py
@@ -32,6 +32,7 @@ from botocore.exceptions import ClientError
 def pytest_addoption(parser):
     parser.addoption("--config", action="store", help="Path to the YAML config file")
     parser.addoption("--profile", action="store", help="profile to use for the tests")
+    parser.addoption("--run-dev", action="store_true", help="Rodar testes no modo dev")
 
 
 @pytest.fixture(autouse=True)
@@ -48,7 +49,6 @@ def skip_based_on_region_marker(s3_client, request):
 
         logging.info(f"\n[Fixture skip_based_on_region_marker] Teste: {request.node.name}")
         logging.info(f"  Marcador 'only_run_in_region' encontrado com regiões: {regions_to_run}")
-        logging.info(f"  Região atual do cliente Boto3 ({s3_client.__class__.__name__}): {current_region}")
 
         if current_region not in regions_to_run:
             skip_message = f"Teste pulado porque a região do cliente não está na lista de skip do marcador {regions_to_run}"
@@ -57,9 +57,21 @@ def skip_based_on_region_marker(s3_client, request):
         else:
             logging.info("Região atual está na lista de regiões onde o teste pode ser executado.")
 
+@pytest.fixture(autouse=True)
+def skip_if_is_dev_run(s3_client, request):
+    marker = request.node.get_closest_marker("skip_if_dev")
+    isDevRun = request.config.getoption("--run-dev")
+    if marker:
+        if isDevRun:
+            pytest.skip("This test doesn't working with dev mode")
+
 @pytest.fixture(scope="session", autouse=True)
-def verify_credentials(get_clients):
+def verify_credentials(get_clients, request):
     tenants = get_tenants(get_clients)
+    isDevRun = request.config.getoption("--profile")
+
+    if isDevRun:
+        return
 
     if not len(tenants) == len(set(tenants)) or len(tenants) < 2:
         pytest.exit("Perfis estão configurados de forma incorreta. É necessário que tenha dois perfis configurados para diferentes owners")
@@ -72,7 +84,7 @@ def test_params(request):
     config_path = request.config.getoption("--config") or os.environ.get("CONFIG_PATH", "../params.example.yaml")
     
     profile = request.config.getoption("--profile") or os.environ.get("PROFILE", None)
-    logging.info(f"Region: {profile}")
+    logging.info(f"Profile: {profile}")
     with open(config_path, "r") as f:
         config = yaml.safe_load(f)
         if not profile:

--- a/src/s3_specs/docs/consistency_test.py
+++ b/src/s3_specs/docs/consistency_test.py
@@ -129,6 +129,7 @@ def setup_versioned_bucket(session_active_mgc_workspace, session_versioned_bucke
 @pytest.mark.slow
 @pytest.mark.multiple_objects
 @pytest.mark.consistency
+@pytest.mark.skip_if_dev
 @pytest.mark.parametrize("command", ["get-object", "list-objects", "head-object", "count-objects"])
 @pytest.mark.parametrize("quantity", [512])  # Quantidade de arquivos a serem adicionados
 @pytest.mark.parametrize("workers", [256])  # Número de workers para o upload

--- a/src/s3_specs/docs/list_buckets_test.py
+++ b/src/s3_specs/docs/list_buckets_test.py
@@ -41,7 +41,7 @@ import subprocess
 from shlex import split, quote
 from s3_specs.docs.s3_helpers import run_example
 
-pytestmark = pytest.mark.basic
+pytestmark = [pytest.mark.basic, pytest.mark.homologacao]
 config = os.getenv("CONFIG", config)
 # -
 

--- a/src/s3_specs/docs/list_buckets_test_cli.py
+++ b/src/s3_specs/docs/list_buckets_test_cli.py
@@ -40,7 +40,7 @@ import subprocess
 from shlex import split
 from s3_specs.docs.s3_helpers import run_example
 
-pytestmark = pytest.mark.cli
+pytestmark = [pytest.mark.cli, pytest.mark.homologacao]
 config = os.getenv("CONFIG", config)
 # -
 

--- a/src/s3_specs/docs/locking_cli_test.py
+++ b/src/s3_specs/docs/locking_cli_test.py
@@ -32,7 +32,7 @@ from s3_specs.docs.s3_helpers import (
     get_object_retention_with_determination,
 )
 from datetime import datetime, timedelta, timezone
-pytestmark = [pytest.mark.locking, pytest.mark.cli]
+pytestmark = [pytest.mark.locking, pytest.mark.cli, pytest.mark.homologacao]
 # -
 
 # ## Exemplos

--- a/src/s3_specs/docs/locking_test.py
+++ b/src/s3_specs/docs/locking_test.py
@@ -52,7 +52,7 @@ from s3_specs.docs.tools.crud import fixture_bucket_with_name
 from s3_specs.docs.tools.locking import bucket_with_lock_enabled
 
 config = os.getenv("CONFIG", config)
-pytestmark = pytest.mark.locking
+pytestmark = [pytest.mark.locking, pytest.mark.homologacao]
 # -
 
 # ### Criando um novo bucket, já com locking habilitado

--- a/src/s3_specs/docs/multiple_objects_test.py
+++ b/src/s3_specs/docs/multiple_objects_test.py
@@ -12,6 +12,8 @@ from s3_specs.docs.tools.crud import (fixture_bucket_with_name,
 # A função abaixo faz o upload de N objects para um bucket S3 e então os deleta.
 
 # Multiple objects test data
+pytestmark = [pytest.mark.skip_if_dev]
+
 objects_number = [100, 1_000, 10_000]
 file_path = "../AUTHORS"
 

--- a/src/s3_specs/docs/object_basic_test.py
+++ b/src/s3_specs/docs/object_basic_test.py
@@ -23,7 +23,7 @@ import os
 import secrets
 import botocore
 
-pytestmark = pytest.mark.basic
+pytestmark = [pytest.mark.basic, pytest.mark.homologacao]
 config = os.getenv("CONFIG", config)
 # -
 

--- a/src/s3_specs/docs/object_download_cli.py
+++ b/src/s3_specs/docs/object_download_cli.py
@@ -25,7 +25,7 @@ from shlex import split
 from s3_specs.docs.s3_helpers import (
     run_example,
 )
-pytestmark = [pytest.mark.basic, pytest.mark.cli]
+pytestmark = [pytest.mark.basic, pytest.mark.cli, pytest.mark.homologacao]
 # -
 
 # + tags=["parameters"]

--- a/src/s3_specs/docs/object_locking_cli.py
+++ b/src/s3_specs/docs/object_locking_cli.py
@@ -13,7 +13,7 @@ from s3_specs.docs.tools.locking import bucket_with_lock_enabled, fixture_bucket
 
 config = "../params/br-se1.yaml"
 
-pytestmark = [pytest.mark.bucket_versioning, pytest.mark.cli]
+pytestmark = [pytest.mark.locking, pytest.mark.cli, pytest.mark.homologacao]
 
 ## # Bucket locking
 object_lock_json = json.dumps({

--- a/src/s3_specs/docs/objects_list_cli.py
+++ b/src/s3_specs/docs/objects_list_cli.py
@@ -29,7 +29,7 @@ from shlex import split
 from s3_specs.docs.s3_helpers import (
     run_example,
 )
-pytestmark = [pytest.mark.basic, pytest.mark.cli]
+pytestmark = [pytest.mark.basic, pytest.mark.cli, pytest.mark.homologacao]
 
 # -
 

--- a/src/s3_specs/docs/permission_test_cli.py
+++ b/src/s3_specs/docs/permission_test_cli.py
@@ -7,7 +7,7 @@ from s3_specs.docs.tools.permission import fixture_public_bucket, fixture_privat
 from botocore.exceptions import ClientError
 from s3_specs.docs.s3_helpers import get_tenants
 
-pytestmark = pytest.mark.acl
+pytestmark = [pytest.mark.acl, pytest.mark.homologacao]
 config = "../params/br-se1.yaml"
 logging.basicConfig(level=logging.INFO)
 

--- a/src/s3_specs/docs/policies_test.py
+++ b/src/s3_specs/docs/policies_test.py
@@ -32,7 +32,7 @@ from s3_specs.docs.s3_helpers import(
     change_policies_json,
 )
 config = os.getenv("CONFIG", config)
-pytestmark = pytest.mark.policy
+pytestmark = [pytest.mark.policy, pytest.mark.skip_if_dev]
 # -
 
 # Políticas de bucket são descritas por meio de arquivos no formato JSON, que seguem uma gramática

--- a/src/s3_specs/docs/policies_test.py
+++ b/src/s3_specs/docs/policies_test.py
@@ -32,7 +32,7 @@ from s3_specs.docs.s3_helpers import(
     change_policies_json,
 )
 config = os.getenv("CONFIG", config)
-pytestmark = [pytest.mark.policy, pytest.mark.skip_if_dev]
+pytestmark = [pytest.mark.policy, pytest.mark.skip_if_dev, pytest.mark.homologacao]
 # -
 
 # Políticas de bucket são descritas por meio de arquivos no formato JSON, que seguem uma gramática

--- a/src/s3_specs/docs/profiles_policies_test.py
+++ b/src/s3_specs/docs/profiles_policies_test.py
@@ -23,8 +23,10 @@ import os
 import pytest
 from botocore.exceptions import ClientError
 from s3_specs.docs.s3_helpers import(run_example)
+import logging
+
 config = os.getenv("CONFIG", config)
-pytestmark = pytest.mark.policy
+pytestmark = [pytest.mark.policy, pytest.mark.skip_if_dev]
 
 policy_dict_template = {
     "Version": "2012-10-17",
@@ -126,6 +128,7 @@ def test_allowed_policy_operations(multiple_s3_clients, bucket_with_one_object_p
     
     method = getattr(allowed_client, boto3_action)
     response = method(**kwargs)
+    logging.info(f"REQUEST RESPONSE: {response}")
     assert response['ResponseMetadata']['HTTPStatusCode'] == expected
 run_example(__name__, "test_allowed_policy_operations", config=config)
 

--- a/src/s3_specs/docs/profiles_policies_test.py
+++ b/src/s3_specs/docs/profiles_policies_test.py
@@ -26,7 +26,7 @@ from s3_specs.docs.s3_helpers import(run_example)
 import logging
 
 config = os.getenv("CONFIG", config)
-pytestmark = [pytest.mark.policy, pytest.mark.skip_if_dev]
+pytestmark = [pytest.mark.policy, pytest.mark.skip_if_dev, pytest.mark.homologacao]
 
 policy_dict_template = {
     "Version": "2012-10-17",

--- a/src/s3_specs/docs/service_account_test.py
+++ b/src/s3_specs/docs/service_account_test.py
@@ -9,7 +9,7 @@ from s3_specs.docs.tools.utils import execute_subprocess
 from s3_specs.docs.tools.service_account import profile_name_sa, active_mgc_workspace_sa, get_sa_infos, bucket_with_one_object_and_bucket_policy
 from pathlib import Path # Para lidar com caminhos de arquivo de forma mais robusta
 
-pytestmark = [pytest.mark.service_account, pytest.mark.cli, pytest.mark.skip_if_dev]
+pytestmark = [pytest.mark.service_account, pytest.mark.cli, pytest.mark.skip_if_dev, pytest.mark.homologacao]
 
 commands = [
     pytest.param(

--- a/src/s3_specs/docs/service_account_test.py
+++ b/src/s3_specs/docs/service_account_test.py
@@ -9,7 +9,7 @@ from s3_specs.docs.tools.utils import execute_subprocess
 from s3_specs.docs.tools.service_account import profile_name_sa, active_mgc_workspace_sa, get_sa_infos, bucket_with_one_object_and_bucket_policy
 from pathlib import Path # Para lidar com caminhos de arquivo de forma mais robusta
 
-pytestmark = [pytest.mark.service_account, pytest.mark.cli]
+pytestmark = [pytest.mark.service_account, pytest.mark.cli, pytest.mark.skip_if_dev]
 
 commands = [
     pytest.param(

--- a/src/s3_specs/docs/unique_bucket_name_test.py
+++ b/src/s3_specs/docs/unique_bucket_name_test.py
@@ -23,7 +23,7 @@ import logging
 import os
 from s3_specs.docs.s3_helpers import run_example, create_bucket
 
-pytestmark = [pytest.mark.basic, pytest.mark.skip_if_dev]
+pytestmark = [pytest.mark.basic, pytest.mark.skip_if_dev, pytest.mark.homologacao]
 config = os.getenv("CONFIG", config)
 # -
 

--- a/src/s3_specs/docs/unique_bucket_name_test.py
+++ b/src/s3_specs/docs/unique_bucket_name_test.py
@@ -23,7 +23,7 @@ import logging
 import os
 from s3_specs.docs.s3_helpers import run_example, create_bucket
 
-pytestmark = pytest.mark.basic
+pytestmark = [pytest.mark.basic, pytest.mark.skip_if_dev]
 config = os.getenv("CONFIG", config)
 # -
 

--- a/src/s3_specs/docs/versioning_cli_test.py
+++ b/src/s3_specs/docs/versioning_cli_test.py
@@ -11,7 +11,7 @@ from s3_specs.docs.tools.versioning import fixture_versioned_bucket, fixture_ver
 config = "../params/br-se1.yaml"
 
 # + {"jupyter": {"source_hidden": true}}
-pytestmark = [pytest.mark.bucket_versioning, pytest.mark.cli]
+pytestmark = [pytest.mark.bucket_versioning, pytest.mark.cli, pytest.mark.homologacao]
 
 
 # Acl related tests


### PR DESCRIPTION
## Categoria do PR? 

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimização
- [ ] Documentação
- [x] Testes

## Motivação do PR
Facilitar o processo de run nos testes durante o desenvolvimento ou homologação de novas features

## Descrição do PR
    Foi adicionado uma flag --dev-run no pytest indicando que é uma dev run para skipar algumas restrições relacionadas a profile e skipar testes que são incompativeis com ambiente de desenvolvimento. Também foi adicionado uma recipe dev no justfile como um atalho para usar no modo dev.
    Além disso, foi adicionado uma tag homologacao que roda todos os testes que utilizamos em homologação, e uma recipe no justfile `homologate` que já aplica a tag e executa os testes de homologação.