### PR TITLE
feat: add RBAC tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,8 @@ markers = [
     "aws: aws cli",
     "rclone: rclone cli",
     "service_account: Service Account",
-    "bucket_sharing: Bucket Sharing"
+    "bucket_sharing: Bucket Sharing",
+    "rbac: Only run rbac tests, which require a specific configuration"
 ]
 
 [tool.s3-tester]

--- a/src/s3_specs/docs/rbac_test.py
+++ b/src/s3_specs/docs/rbac_test.py
@@ -1,0 +1,73 @@
+import os
+import logging
+import time
+import pytest
+from botocore.exceptions import ClientError
+from s3_specs.docs.s3_helpers import run_example
+
+
+pytestmark = [pytest.mark.rbac]
+
+config = "../params/br-ne1.yaml"
+config = os.getenv("CONFIG", config)
+
+
+# INFO: These key pairs are hard coded because clients have to have correct
+# permissioning in Magalu Cloud console.
+@pytest.mark.parametrize(
+    'rbac_s3_client, results',
+    [
+       (0, (False, False)),
+       (1, (True, False)),
+       (2, (True, True))
+    ],
+    indirect=['rbac_s3_client'],
+    ids=[f'client[rbac{id+1}]' for id in range(3)]
+)
+@pytest.mark.parametrize(
+    'boto3_action',
+    ['list_buckets', 'create_bucket']
+)
+def test_rbac_permissions(rbac_s3_client, boto3_action, results):
+    kwargs = {}
+
+    positive_result = results[0]
+    if boto3_action == 'create_bucket':
+        positive_result = results[1]
+        bucket_name = 'test-' + str(int(time.time()))
+        kwargs = {
+            'Bucket': bucket_name,  # Set 'Bucket' value from the variable
+        }
+
+    logging.info(f"call boto3_action:{boto3_action}, with args:{kwargs}")
+    method = getattr(rbac_s3_client, boto3_action)
+    try:
+        response = method(**kwargs)
+        logging.info(f"Method response:{response}")
+        if not positive_result:
+            pytest.fail("Expected exception not raised")
+    except ClientError as e:
+        logging.info(f"Method error response:{e.response}")
+        if positive_result:
+            pytest.fail(f"Should not raise exception, raised: {e}")
+    finally:
+        if kwargs.get('Bucket') is not None:
+            cleanup_bucket(rbac_s3_client, kwargs['Bucket'])
+
+
+run_example(__name__, "test_rbac_permissions", config=config)
+
+
+def cleanup_bucket(s3_client, bucket_name):
+    try:
+        # Listar e excluir todos os objetos
+        objects = s3_client.list_objects_v2(Bucket=bucket_name)
+        if 'Contents' in objects:
+            for obj in objects['Contents']:
+                s3_client.delete_object(Bucket=bucket_name, Key=obj['Key'])
+        
+        # Excluir o bucket
+        s3_client.delete_bucket(Bucket=bucket_name)
+        logging.info(f"Bucket {bucket_name} removido com sucesso")
+    except Exception as e:
+        logging.warning(f"Erro ao limpar bucket {bucket_name}: {str(e)}")


### PR DESCRIPTION
## Categoria do PR? 

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimização
- [ ] Documentação
- [x] Testes

## Motivação do PR
Adicionar testes para validação de permissões de RBAC

## Descrição do PR
Adiciona caso de teste para validar diferentes clientes, com diferentes permissões de RBAC, para validar que essas permissões estão sendo aplicadas corretamente.

Obs: as chaves são fixas pois elas pertencem a contas com permissões específicas, cuja manipulação está fora do escopo possível nos testes do repositório. Portanto, essas contas foram criadas previamente e as chaves delas deverão SEMPRE ser usadas nestes testes. Uma forma de escondê-las em bem vinda.

https://kanban-force.web.app/boards/63d991aaf03baf6cfdc0f999?cardId=682b27c21948acd079d731bf