### PR TITLE
Fix/mgc race

### DIFF
--- a/.github/workflows/generate-docker-image-on-push.yml
+++ b/.github/workflows/generate-docker-image-on-push.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - skip-test-crossaccount
+      - fix/mgc_race
+
 jobs:
   build:
     permissions:

--- a/bin/configure_profiles.py
+++ b/bin/configure_profiles.py
@@ -74,13 +74,18 @@ def configure_profiles(profiles):
             access_key = profile_data.get("access_key")
             secret_key = profile_data.get("secret_key")
             region = profile_data.get("region")
+            missing_fields = [k for k, v
+                              in {"endpoint": endpoint, "access_key": access_key, "secret_key": secret_key, "region": region}.items()
+                              if v is None]
 
             if not (endpoint and access_key and secret_key and region):
-                print(f"Perfil {profile_name} está incompleto. Ignorando...")
+                print(f"Perfil {profile_name} está incompleto. Falta {
+                      missing_fields}. Ignorando...")
                 continue
-            
-            if (access_key == "YOUR-KEY-ID-HERE" or secret_key == "YOUR-SECRET-KEY-HERE" ):
-                print(f"Perfil {profile_name} está incompleto. Ignorando...")
+
+            if (access_key == "YOUR-KEY-ID-HERE" or secret_key == "YOUR-SECRET-KEY-HERE"):
+                print(f"Perfil {
+                      profile_name} está incompleto. Por favor, configure as chaves. Ignorando...")
                 continue
 
             set_aws_profiles(profile_name=profile_name, data=profile_data)

--- a/justfile
+++ b/justfile
@@ -15,6 +15,10 @@ _default:
 #Configure profiles in the CLI's
 setup-profiles:
     uv run ./bin/configure_profiles.py ./params.example.yaml
+    mkdir -p fakehomes/mgc-second/.config
+    cp -r ~/.config/mgc fakehomes/mgc-second/.config
+    cp -r ~/.config/rclone fakehomes/mgc-second/.config
+    cp -r ~/.aws fakehomes/mgc-second
 
 # Run the tests
 _run_tests config_file *pytest_params:
@@ -27,11 +31,11 @@ _run_specific_test_file config_file test_name *pytest_params:
     uv run pytest ./src/s3_specs/docs/{{test_name}} --config {{config_file}} {{pytest_params}}
 
 _run_dev_tests *pytest_params:
-    uv run pytest ./src/s3_specs/docs/ --config ./params.example.yaml -m '(not consistency) and (not benchmark) and (not mgc)' {{pytest_params}} --run-dev 
+    uv run pytest ./src/s3_specs/docs/ --config ./params.example.yaml -m '(not consistency) and (not benchmark) and (not mgc)' {{pytest_params}} --run-dev
 
 #Execute the tests of s3-specs generating reports
 tests category mark = "" : setup-profiles
-    # just _run_tests "./params.example.yaml" 
+    # just _run_tests "./params.example.yaml"
     just _run_tests_with_report {{category}} {{mark}}
 
 #Execute the tests of s3-specs using pytest

--- a/src/s3_specs/docs/conftest.py
+++ b/src/s3_specs/docs/conftest.py
@@ -158,6 +158,13 @@ def active_mgc_workspace(profile_name, mgc_path):
 
     logging.info(f"mcg workspace set stdout: {result.stdout}")
     return profile_name
+    
+    
+@pytest.fixture
+def active_mgc_workspace_second_env():
+    return {
+        'HOME': 'fakehomes/mgc-second'
+    }
 
 @pytest.fixture
 def s3_client(default_profile):

--- a/src/s3_specs/docs/conftest.py
+++ b/src/s3_specs/docs/conftest.py
@@ -153,7 +153,8 @@ def active_mgc_workspace(profile_name, mgc_path):
     result = subprocess.run([mgc_path, "workspace", "set", profile_name],
                             capture_output=True, text=True)
     if result.returncode != 0:
-        pytest.skip("This test requires an mgc profile name")
+        raise Exception(f"Failed setting correct profile for mgc cli: {result.stdout}")
+        # pytest.error("This test requires an mgc profile name")
 
     logging.info(f"mcg workspace set stdout: {result.stdout}")
     return profile_name

--- a/src/s3_specs/docs/permission_cli_test.py
+++ b/src/s3_specs/docs/permission_cli_test.py
@@ -60,7 +60,7 @@ download_commands = [
 ]
 
 @pytest.mark.parametrize("cmd_template", list_commands)
-def test_list_objects(active_mgc_workspace_second, fixture_public_bucket, cmd_template, profile_name_second):
+def test_list_objects(active_mgc_workspace_second, active_mgc_workspace_second_env, fixture_public_bucket, cmd_template, profile_name_second):
     """Verifica se é possível listar objetos em um bucket público usando diferentes CLIs."""
     bucket_name, obj_key = fixture_public_bucket
     cmd = cmd_template["command"].format(
@@ -68,7 +68,7 @@ def test_list_objects(active_mgc_workspace_second, fixture_public_bucket, cmd_te
         profile_name_second=profile_name_second
     )
     logging.info(f"Executing list command: {cmd}")
-    result = execute_subprocess(cmd)
+    result = execute_subprocess(cmd, env=active_mgc_workspace_second_env)
     assert result.returncode == 0, (
         f"List command failed with exit code {result.returncode}\n"
         f"Command: {cmd}\n"
@@ -84,6 +84,7 @@ def test_list_objects(active_mgc_workspace_second, fixture_public_bucket, cmd_te
 @pytest.mark.parametrize("cmd_template", download_commands)
 def test_download_object_expected_failure(
     active_mgc_workspace_second,
+    active_mgc_workspace_second_env,
     fixture_public_bucket,
     cmd_template,
     profile_name_second,
@@ -112,7 +113,7 @@ def test_download_object_expected_failure(
 
     logging.info(f"Executing download command (EXPECTED TO FAIL): {cmd}")
 
-    result = subprocess.run(cmd, shell=True, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True, check=False, env=active_mgc_workspace_second_env)
 
     assert expected_output_in_stderr in result.stderr, (
         f"Erro esperado '{expected_output_in_stderr}' não encontrado no stderr:\n{result.stderr}"
@@ -124,6 +125,7 @@ def test_download_object_expected_failure(
 @pytest.mark.parametrize("cmd_template", list_commands)
 def test_list_objects_expected_failure(
     active_mgc_workspace_second,
+    active_mgc_workspace_second_env,
     fixture_private_bucket,
     cmd_template,
     profile_name_second,
@@ -152,7 +154,7 @@ def test_list_objects_expected_failure(
 
     logging.info(f"Executing list bucket command (EXPECTED TO FAIL): {cmd}")
 
-    result = subprocess.run(cmd, shell=True, capture_output=True, text=True, check=False)
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True, check=False, env=active_mgc_workspace_second_env)
 
     # Verifica que o erro esperado está no stderr
     assert expected_output_in_stderr in result.stderr, (
@@ -192,6 +194,7 @@ cli_commands = [
 @pytest.mark.parametrize("cli_info", cli_commands)
 def test_put_object_acl(
     active_mgc_workspace_second,
+    active_mgc_workspace_second_env,
     multiple_s3_clients,
     fixture_private_bucket,
     profile_name,
@@ -243,7 +246,7 @@ def test_put_object_acl(
          pytest.fail(f"Falha ao gerar o comando para {cli_name} com ACL {acl_info}")
 
     logging.info(f"Executando: {cmd}")
-    result = execute_subprocess(cmd)
+    result = execute_subprocess(cmd, env=active_mgc_workspace_second_env)
 
     assert result.returncode == 0, (
         f"Falha ao executar put-object-acl.\n"
@@ -285,6 +288,7 @@ cli_validate_templates = {
 )
 def test_set_acl_boto3_validate_cli_read(
     active_mgc_workspace_second,
+    active_mgc_workspace_second_env,
     multiple_s3_clients,
     fixture_private_bucket,
     profile_name_second,
@@ -348,7 +352,7 @@ def test_set_acl_boto3_validate_cli_read(
 
 
     try:
-        result_validate = execute_subprocess(cmd_validate, expected_failure=expect_cmd_fail)
+        result_validate = execute_subprocess(cmd_validate, expected_failure=expect_cmd_fail, env=active_mgc_workspace_second_env)
     except Exception as e:
         pytest.fail(f"execute_subprocess failed or expectation not met: {e}\nCommand: {cmd_validate}\nExpected failure: {expect_cmd_fail}")
 

--- a/src/s3_specs/docs/tools/permission.py
+++ b/src/s3_specs/docs/tools/permission.py
@@ -46,10 +46,10 @@ def profile_name_second(test_params, profile_name):
     return f"{profile_name}-second"
 
 @pytest.fixture
-def active_mgc_workspace_second(profile_name_second, mgc_path):
+def active_mgc_workspace_second(profile_name_second, mgc_path, active_mgc_workspace_second_env):
     # set the profile
     result = subprocess.run([mgc_path, "workspace", "set", profile_name_second],
-                            capture_output=True, text=True)
+                            capture_output=True, text=True, env=active_mgc_workspace_second_env)
     if result.returncode != 0:
         raise Exception(f"Failed setting correct profile for mgc cli: {result.stdout}")
         # pytest.skip("This test requires an mgc profile name")

--- a/src/s3_specs/docs/tools/permission.py
+++ b/src/s3_specs/docs/tools/permission.py
@@ -51,7 +51,8 @@ def active_mgc_workspace_second(profile_name_second, mgc_path):
     result = subprocess.run([mgc_path, "workspace", "set", profile_name_second],
                             capture_output=True, text=True)
     if result.returncode != 0:
-        pytest.skip("This test requires an mgc profile name")
+        raise Exception(f"Failed setting correct profile for mgc cli: {result.stdout}")
+        # pytest.skip("This test requires an mgc profile name")
 
     logging.info(f"mcg workspace set stdout: {result.stdout}")
     return profile_name_second

--- a/src/s3_specs/docs/tools/utils.py
+++ b/src/s3_specs/docs/tools/utils.py
@@ -113,7 +113,7 @@ def fixture_create_small_file(tmp_path_factory: pytest.TempdirFactory):
     assert os.path.exists(tmp_path), "Temporary object not created"
     return tmp_path
 
-def execute_subprocess(cmd_command: str, expected_failure:bool = False):
+def execute_subprocess(cmd_command: str, expected_failure:bool = False, env=None):
     """
     Execute a shell command as a subprocess and handle errors gracefully.
     
@@ -143,7 +143,8 @@ def execute_subprocess(cmd_command: str, expected_failure:bool = False):
             shell=True,
             capture_output=True,  # Capture stdout and stderr
             text=True,           # Return output as strings (not bytes)
-            check=True           # Raise CalledProcessError if returncode != 0
+            check=True,           # Raise CalledProcessError if returncode != 0
+            env=env
         )
     except subprocess.CalledProcessError as e:
         # Propagate the error to the query 


### PR DESCRIPTION
## Categoria do PR? 

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimização
- [ ] Documentação
- [ ] Testes

## Motivação do PR
O setup de profiles do mgc_cli utiliza um único arquivo de configuração para definir qual perfil será utilizado.
Isso se torna um problema no momento que 2 testes com perfis diferentes executam em paralelo. Isso pode causar uma
race condition, na qual um teste acredita estar no perfil correto quando, na verdade, o outro teste mudou o perfil enquanto o primeiro executava.

Isso causa um fluxo no seguinte formato:
1. test 1 configura perfil 1 para execução
2. test 1 cria um bucket no perfil 1 como preparação para o teste
3. test 2 configura perfil 2 para execução
4. test 1 tenta acessar o bucket criado em 2 (perfil ativado é 2)
5. test 1 recebe erro de acesso (AccessDenied)

## Descrição do PR
1. Evitar erros silenciosos: o setup de perfil estava, de fato, realizando um `skip` toda vez que o perfil da mgc cli não era setado corretamente. Isso faz com que erros sejam passados silenciosamente, perfis não sejam configurados corretamente e alguns testes não sejam executados. Mudamos isto para configurar erro.
2. Criação de fakehomes: mgc cli sempre procura por qual perfil utilizar em `$HOME/.mgc/current`. Adicionamos a criação de uma pasta que simula a home do usuário, a qual pode ser apontada apenas mudando a variável `$HOME` no ambiente de execução do comando `mgc`
3. Criação de variável de ambiente para execução dos testes de `mgc-second-profile`. Todos os comandos agora rodam com `$HOME=fakehomes/mgc-second`

## Pós deploy:
Idealmente, a utilização de diferentes profiles ao mesmo tempo deveria ser feature da CLI. Propor a feature seria ideal.

## Link do Card no Kanban
[BUG-8B10](https://kanban-force.web.app/boards/63d991aaf03baf6cfdc0f999?cardId=6863d64ef9f09ce578c18b10)