### PR TITLE
improve: server url on config file mgc

### DIFF
--- a/bin/configure_profiles.py
+++ b/bin/configure_profiles.py
@@ -66,6 +66,7 @@ def set_mgc_profiles(profile_name, data):
     cli_file_path = os.path.join(profile_dir, "cli.yaml")
     with open(cli_file_path, "w") as cli_file:
         cli_file.write(f"region: {data.get('region')}\n")
+        cli_file.write(f"serverurl:: {data.get('endpoint')}\n")
 
 def configure_profiles(profiles):
     try:


### PR DESCRIPTION
Adicionar server-url no config file da mgc-cli, permitindo o uso com qualquer backend.