### PR TITLE
feat: rerun tests multiple times to prevent inconsistency

### DIFF
--- a/.github/workflows/recurrent-tests-1h.yml
+++ b/.github/workflows/recurrent-tests-1h.yml
@@ -26,7 +26,7 @@ jobs:
       name: "${{ matrix.marker.name }}_1hours.${{ matrix.config.name }}"
       config: ${{ matrix.config.path }}
       profile: ${{ matrix.profile }}
-      flags: "--no-header -vv -n auto --tb=line --color=no -m ${{ matrix.marker.test }} --tb=line --log-cli-level=info"
+      flags: "--no-header -vv -n auto --tb=line --color=no -m ${{ matrix.marker.test }} --tb=line --log-cli-level=info --reruns 15"
     secrets:
       PROFILES: ${{ secrets.PROFILES }}
 

--- a/.github/workflows/recurrent-tests-6h.yml
+++ b/.github/workflows/recurrent-tests-6h.yml
@@ -27,6 +27,6 @@ jobs:
       name: "${{ matrix.marker.name }}_6hours.${{ matrix.config.name }}"
       config: ${{ matrix.config.path }}
       profile: ${{ matrix.profile }}
-      flags: "--no-header -vv -n 1 --tb=line --color=no -m ${{ matrix.marker.test }} --tb=line --log-cli-level=info"
+      flags: "--no-header -vv -n 1 --tb=line --color=no -m ${{ matrix.marker.test }} --tb=line --log-cli-level=info --reruns 15"
     secrets:
       PROFILES: ${{ secrets.PROFILES }}


### PR DESCRIPTION
Apenas adiciona retries nos testes que falham para tentar desconsiderar inconsistências

Ainda depende da sorte, pois inconsistências ocorrem, principalmente, por load balancer - que vai guiar os resultados para diferentes intâncias do servidor. Esperar não afeta o resultado tanto, mas fazer vários traz mais chance de atingir o servidor correto