### PR TITLE
chore: re-activate workers

### DIFF
--- a/.github/workflows/recurrent-tests-6h.yml
+++ b/.github/workflows/recurrent-tests-6h.yml
@@ -27,6 +27,6 @@ jobs:
       name: "${{ matrix.marker.name }}_6hours.${{ matrix.config.name }}"
       config: ${{ matrix.config.path }}
       profile: ${{ matrix.profile }}
-      flags: "--no-header -vv -n 1 --tb=line --color=no -m ${{ matrix.marker.test }} --tb=line --log-cli-level=info --reruns 15"
+      flags: "--no-header -vv -n auto --tb=line --color=no -m ${{ matrix.marker.test }} --tb=line --log-cli-level=info --reruns 15"
     secrets:
       PROFILES: ${{ secrets.PROFILES }}


### PR DESCRIPTION
## Motivação do PR
Com a atualização da mgc-cli aceitando env para setar workspace esse teste pode ser paralelizado diminuindo tempo de run.