### PR TITLE
add a skip to list buckets test to avoid timeout

### DIFF
--- a/src/s3_specs/docs/list_buckets_test.py
+++ b/src/s3_specs/docs/list_buckets_test.py
@@ -52,6 +52,7 @@ config = os.getenv("CONFIG", config)
 # O comando para listar buckets no boto3 é o `list_buckets`.
 
 # +
+@pytest.mark.skip("This is a very expensive operation that may result in timeout")
 def test_list_buckets(s3_client):
     response = s3_client.list_buckets(MaxBuckets=100)
     response_status = response["ResponseMetadata"]["HTTPStatusCode"]


### PR DESCRIPTION
## Categoria do PR? 

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimização
- [ ] Documentação
- [ ] Testes

## Motivação do PR
Estamos com problemas de receber timeouts ao tentar listar buckets muito grandes.

## Descrição do PR
Para evitar o timeout em buckets muito grandes, estamos adicionando um skip temporariamente aos testes de list_buckets
